### PR TITLE
Use `abort_if`

### DIFF
--- a/src/Http/Controllers/CreateSecurityCookieController.php
+++ b/src/Http/Controllers/CreateSecurityCookieController.php
@@ -8,9 +8,7 @@ class CreateSecurityCookieController
 {
     public function __invoke(Request $request)
     {
-        if ($request->get('secret') !== config('native-php.secret')) {
-            return abort(403);
-        }
+        abort_if($request->get('secret') !== config('native-php.secret'), 403);
 
         return redirect('/')->cookie(cookie(
             name: '_php_native',


### PR DESCRIPTION
We can use `abort_if` instead of `abort` and also is no need to return abort because throw an exception!