### PR TITLE
Update ProgressBar.php

### DIFF
--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -7,12 +7,10 @@ use Native\Laravel\Client\Client;
 class ProgressBar
 {
     protected float $percent = 0;
-
     protected int $step = 0;
-
     protected float $lastWriteTime = 0;
-
     protected float $minSecondsBetweenRedraws = 0.1;
+    protected float $maxSecondsBetweenRedraws = 1; // Add the missing property
 
     public function __construct(protected int $maxSteps, protected Client $client)
     {

--- a/src/ProgressBar.php
+++ b/src/ProgressBar.php
@@ -10,7 +10,7 @@ class ProgressBar
     protected int $step = 0;
     protected float $lastWriteTime = 0;
     protected float $minSecondsBetweenRedraws = 0.1;
-    protected float $maxSecondsBetweenRedraws = 1; // Add the missing property
+    protected float $maxSecondsBetweenRedraws = 1;
 
     public function __construct(protected int $maxSteps, protected Client $client)
     {


### PR DESCRIPTION
In this improved version, the missing property $maxSecondsBetweenRedraws has been added, and it is set to a default value of 1. The code should now work as intended without any errors.