### PR TITLE
Add node version to bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -47,6 +47,14 @@ body:
         placeholder: 9.0.0
       validations:
         required: true
+    - type: input
+      id: node-version
+      attributes:
+        label: Node Version
+        description: What version of Node are you running? Please be as specific as possible
+        placeholder: '18.17'
+      validations:
+        required: true
     - type: dropdown
       id: operating-systems
       attributes:


### PR DESCRIPTION
Looking through the issues at https://github.com/NativePHP/laravel/issues there seem to be a wide array of Node.js-related issues that are tough to replicate without knowing the node-version used when the errors occurs. 

Collecting the version when posting a bug seems like a sensible thing to do.