### PR TITLE
Allow for string events

### DIFF
--- a/src/Http/Controllers/DispatchEventFromAppController.php
+++ b/src/Http/Controllers/DispatchEventFromAppController.php
@@ -9,10 +9,13 @@ class DispatchEventFromAppController
     public function __invoke(Request $request)
     {
         $event = $request->get('event');
-        if (class_exists($event)) {
-            $event = new $event(...$request->get('payload', []));
+        $payload = $request->get('payload', []);
 
+        if (class_exists($event)) {
+            $event = new $event(...$payload);
             event($event);
+        } else {
+            event($event, $payload);
         }
 
         return response()->json([


### PR DESCRIPTION
String events are especially useful for passing custom data to the listener. Consider the following:

```php
use Native\Laravel\Client\Client;
use Native\Laravel\Notification;

// Send a notification with a custom event
$client = new Client();
$notification = new Notification($client);

$articleId = 1;
$notification->title('EXTRA EXTRA READ ALL ABOUT IT')
    ->message('You should totally click this)
    ->event('notification.clicked.newArticle' . $articleId)
    ->show();

// Listen to the notification
Event::listen('notification.clicked.newArticle.*', function ($event) {
    $event = explode('.', $event)
    $articleId = array_last($event);
    // do stuff...
});
```