### PR TITLE
Adds 'php artisan native:migrate fresh' command

### DIFF
--- a/src/Commands/FreshCommand.php
+++ b/src/Commands/FreshCommand.php
@@ -16,6 +16,8 @@ class FreshCommand extends Command
         unlink(config('nativephp-internal.database_path'));
 
         (new NativeServiceProvider($this->laravel))->rewriteDatabase();
+
+        $this->call('native:migrate');
     }
 
 }

--- a/src/Commands/FreshCommand.php
+++ b/src/Commands/FreshCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Native\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Native\Laravel\NativeServiceProvider;
+
+class FreshCommand extends Command
+{
+    protected $description = 'Run the database migrations in the NativePHP development environment';
+
+    protected $signature = 'native:migrate fresh';
+
+    public function handle()
+    {
+        unlink(config('nativephp-internal.database_path'));
+
+        (new NativeServiceProvider($this->laravel))->rewriteDatabase();
+    }
+
+}


### PR DESCRIPTION
To avoid copy/pasting the base Laravel command, because it is internally calling `migrate` instead of `native:migrate` I am simply unlinking the database file and calling the [rewriteDatabase](https://github.com/NativePHP/laravel/blob/0a1f8e9e7cf9dbd1de800f1e5323c2b258e3eab0/src/NativeServiceProvider.php#L77) command.