### PR TITLE
Allow custom php.ini settings

### DIFF
--- a/resources/stubs/NativeAppServiceProvider.php.stub
+++ b/resources/stubs/NativeAppServiceProvider.php.stub
@@ -2,13 +2,10 @@
 
 namespace App\Providers;
 
-use Native\Laravel\Facades\ContextMenu;
-use Native\Laravel\Facades\Dock;
 use Native\Laravel\Facades\Window;
-use Native\Laravel\Facades\GlobalShortcut;
-use Native\Laravel\Menu\Menu;
+use Native\Laravel\Contracts\ProvidesPhpIni;
 
-class NativeAppServiceProvider
+class NativeAppServiceProvider implements ProvidesPhpIni
 {
     /**
      * Executed once the native application has been booted.
@@ -16,43 +13,15 @@ class NativeAppServiceProvider
      */
     public function boot(): void
     {
-        Menu::new()
-            ->appMenu()
-            ->submenu('About', Menu::new()
-                ->link('https://beyondco.de', 'Beyond Code')
-                ->link('https://simonhamp.me', 'Simon Hamp')
-            )
-            ->submenu('View', Menu::new()
-                ->toggleFullscreen()
-                ->separator()
-                ->link('https://laravel.com', 'Learn More', 'CmdOrCtrl+L')
-            )
-            ->register();
+        Window::open();
+    }
 
-        Window::open()
-            ->width(800)
-            ->height(800);
-
-        /**
-            Dock::menu(
-                Menu::new()
-                    ->event(DockItemClicked::class, 'Settings')
-                    ->submenu('Help',
-                        Menu::new()
-                            ->event(DockItemClicked::class, 'About')
-                            ->event(DockItemClicked::class, 'Learn More…')
-                    )
-            );
-
-            ContextMenu::register(
-                Menu::new()
-                    ->event(ContextMenuClicked::class, 'Do something')
-            );
-
-            GlobalShortcut::new()
-                ->key('CmdOrCtrl+Shift+I')
-                ->event(ShortcutPressed::class)
-                ->register();
-        */
+    /**
+     * Return an array of php.ini directives to be set.
+     */
+    public function phpIni(): array
+    {
+        return [
+        ];
     }
 }

--- a/src/Commands/LoadPHPConfigurationCommand.php
+++ b/src/Commands/LoadPHPConfigurationCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Native\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Native\Laravel\Contracts\ProvidesPhpIni;
+
+class LoadPHPConfigurationCommand extends Command
+{
+    protected $signature = 'native:php-ini';
+
+    public function handle()
+    {
+        /** @var ProvidesPhpIni $provider */
+        $provider = app(config('nativephp.provider'));
+        $phpIni = [];
+        if (method_exists($provider, 'phpIni')) {
+            $phpIni = $provider->phpIni();
+        }
+        echo json_encode($phpIni);
+    }
+}

--- a/src/Contracts/ProvidesPhpIni.php
+++ b/src/Contracts/ProvidesPhpIni.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Native\Laravel\Contracts;
+
+interface ProvidesPhpIni
+{
+    public function phpIni(): array;
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Native\Laravel;
 
 use Illuminate\Support\Arr;
+use Native\Laravel\Commands\LoadPHPConfigurationCommand;
 use Native\Laravel\Commands\LoadStartupConfigurationCommand;
 use Native\Laravel\Commands\MigrateCommand;
 use Native\Laravel\Commands\MinifyApplicationCommand;
@@ -20,6 +21,7 @@ class NativeServiceProvider extends PackageServiceProvider
                 MigrateCommand::class,
                 MinifyApplicationCommand::class,
                 LoadStartupConfigurationCommand::class,
+                LoadPHPConfigurationCommand::class,
             ])
             ->hasConfigFile()
             ->hasRoute('api')


### PR DESCRIPTION
This PR adds the ability to define custom php ini settings that will be passed to the static PHP binary when it starts the Laravel app, runs the scheduler and runs the queue worker.

To use this in existing apps, just add the `phpIni` method to your `NativeAppServiceProvider` class.

For example:

```php
<?php

namespace App\Providers;

use Native\Laravel\Facades\Window;
use Native\Laravel\Contracts\ProvidesPhpIni;

class NativeAppServiceProvider implements ProvidesPhpIni
{
    /**
     * Executed once the native application has been booted.
     * Use this method to open windows, register global shortcuts, etc.
     */
    public function boot(): void
    {
        Window::open();
    }


    public function phpIni(): array
    {
        return [
            'memory_limit' => '512M',
            'display_errors' => '1',
            'error_reporting' => 'E_ALL',
            'max_execution_time' => '0',
            'max_input_time' => '0',
        ];
    }
}
```

This PR needs https://github.com/NativePHP/electron-plugin/pull/9