### PR TITLE
Printer support

### DIFF
--- a/src/DataObjects/Printer.php
+++ b/src/DataObjects/Printer.php
@@ -11,8 +11,7 @@ class Printer
         public int $status,
         public bool $isDefault,
         public array $options
-    )
-    {
+    ) {
 
     }
 }

--- a/src/DataObjects/Printer.php
+++ b/src/DataObjects/Printer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Native\Laravel\DataObjects;
+
+class Printer
+{
+    public function __construct(
+        public string $name,
+        public string $displayName,
+        public string $description,
+        public int $status,
+        public bool $isDefault,
+        public array $options
+    )
+    {
+
+    }
+}

--- a/src/System.php
+++ b/src/System.php
@@ -29,6 +29,7 @@ class System
     public function printers(): array
     {
         $printers = $this->client->get('system/printers')->json('printers');
+
         return collect($printers)->map(function ($printer) {
             return new Printer(
                 data_get($printer, 'name'),

--- a/src/System.php
+++ b/src/System.php
@@ -3,6 +3,7 @@
 namespace Native\Laravel;
 
 use Native\Laravel\Client\Client;
+use Native\Laravel\DataObjects\Printer;
 
 class System
 {
@@ -20,5 +21,31 @@ class System
         return $this->client->post('system/prompt-touch-id', [
             'reason' => $reason,
         ])->successful();
+    }
+
+    /**
+     * @return array<\Native\Laravel\DataObjects\Printer>
+     */
+    public function printers(): array
+    {
+        $printers = $this->client->get('system/printers')->json('printers');
+        return collect($printers)->map(function ($printer) {
+            return new Printer(
+                data_get($printer, 'name'),
+                data_get($printer, 'displayName'),
+                data_get($printer, 'description'),
+                data_get($printer, 'status'),
+                data_get($printer, 'isDefault'),
+                data_get($printer, 'options'),
+            );
+        })->toArray();
+    }
+
+    public function print(string $html, Printer $printer = null): void
+    {
+        $this->client->post('system/print', [
+            'html' => $html,
+            'printer' => $printer->name ?? '',
+        ]);
     }
 }


### PR DESCRIPTION
This PR works in combination with https://github.com/NativePHP/electron-plugin/pull/11 and adds support to retrieve information about the available printers, as well as silently (without user interaction) print HTML documents.

```php
$printers = System::printers();

System::print('<h1>Hello World</h1>', $printers[0]);
```