### PR TITLE
Add method to update an existing context-menu of the menu bar

### DIFF
--- a/src/Facades/MenuBar.php
+++ b/src/Facades/MenuBar.php
@@ -3,12 +3,14 @@
 namespace Native\Laravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Native\Laravel\Menu\Menu;
 
 /**
  * @method static \Native\Laravel\MenuBar\PendingCreateMenuBar create()
  * @method static void show()
  * @method static void hide()
  * @method static void label(string $label)
+ * @method static void contextMenu(Menu $contextMenu)
  */
 class MenuBar extends Facade
 {

--- a/src/MenuBar/MenuBarManager.php
+++ b/src/MenuBar/MenuBarManager.php
@@ -3,6 +3,7 @@
 namespace Native\Laravel\MenuBar;
 
 use Native\Laravel\Client\Client;
+use Native\Laravel\Menu\Menu;
 
 class MenuBarManager
 {
@@ -30,6 +31,13 @@ class MenuBarManager
     {
         $this->client->post('menu-bar/label', [
             'label' => $label,
+        ]);
+    }
+
+    public function contextMenu(Menu $contextMenu)
+    {
+        $this->client->post('menu-bar/context-menu', [
+            'contextMenu' => $contextMenu->toArray()['submenu'],
         ]);
     }
 }


### PR DESCRIPTION
# The Situation

Corresponding PR: https://github.com/NativePHP/electron-plugin/pull/14

I'm creating a menubar app, that uses the menu-bar items to display some info.
When that info gets updated, I need to edit the menubar, but the `/create` endpoint cannot be called again.

## Proposed solution
Therefor I've added an endpoint `/context-menu` to update the already set context-menu of the menubar.
