### PR TITLE
Modified return type of clipboard image method

### DIFF
--- a/src/Clipboard.php
+++ b/src/Clipboard.php
@@ -41,7 +41,7 @@ class Clipboard
         return $html;
     }
 
-    public function image($image = null): string
+    public function image($image = null): string|null
     {
         if (is_null($image)) {
             return $this->client->get('clipboard/image')->json('image');

--- a/src/Facades/Clipboard.php
+++ b/src/Facades/Clipboard.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void clear()
  * @method static string text($text = null)
  * @method static string html($html = null)
- * @method static string image($image = null)
+ * @method static string|null image($image = null)
  */
 class Clipboard extends Facade
 {


### PR DESCRIPTION
When the clipboard does not have a image copied(i.e. last copied item is a text) then the `Clipboard::image()` returns `null`.  