### PR TITLE
add windowPosition

### DIFF
--- a/src/Concerns/HasPositioner.php
+++ b/src/Concerns/HasPositioner.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Native\Laravel\Concerns;
+
+trait HasPositioner
+{
+    protected string $windowPosition = 'trayCenter';
+
+    public function windowPosition(string $position): self
+    {
+        $this->windowPosition = $position;
+
+        return $this;
+    }
+
+    public function trayLeft(): self
+    {
+        return $this->windowPosition('trayLeft');
+    }
+
+    public function trayBottomLeft(): self
+    {
+        return $this->windowPosition('trayBottomLeft');
+    }
+
+    public function trayRight(): self
+    {
+        return $this->windowPosition('trayRight');
+    }
+
+    public function trayBottomRight(): self
+    {
+        return $this->windowPosition('trayBottomRight');
+    }
+
+    public function trayCenter(): self
+    {
+        return $this->windowPosition('trayCenter');
+    }
+
+    public function trayBottomCenter(): self
+    {
+        return $this->windowPosition('trayBottomCenter');
+    }
+
+    public function topLeft(): self
+    {
+        return $this->windowPosition('topLeft');
+    }
+
+    public function topRight(): self
+    {
+        return $this->windowPosition('topRight');
+    }
+
+    public function bottomLeft(): self
+    {
+        return $this->windowPosition('bottomLeft');
+    }
+
+    public function bottomRight(): self
+    {
+        return $this->windowPosition('bottomRight');
+    }
+
+    public function topCenter(): self
+    {
+        return $this->windowPosition('topCenter');
+    }
+
+    public function bottomCenter(): self
+    {
+        return $this->windowPosition('bottomCenter');
+    }
+
+    public function leftCenter(): self
+    {
+        return $this->windowPosition('leftCenter');
+    }
+
+    public function rightCenter(): self
+    {
+        return $this->windowPosition('rightCenter');
+    }
+
+    public function center(): self
+    {
+        return $this->windowPosition('center');
+    }
+}

--- a/src/MenuBar/MenuBar.php
+++ b/src/MenuBar/MenuBar.php
@@ -4,6 +4,7 @@ namespace Native\Laravel\MenuBar;
 
 use Native\Laravel\Client\Client;
 use Native\Laravel\Concerns\HasDimensions;
+use Native\Laravel\Concerns\HasPositioner;
 use Native\Laravel\Concerns\HasUrl;
 use Native\Laravel\Concerns\HasVibrancy;
 use Native\Laravel\Menu\Menu;
@@ -12,6 +13,7 @@ class MenuBar
 {
     use HasVibrancy;
     use HasDimensions;
+    use HasPositioner;
     use HasUrl;
 
     protected string $icon = '';
@@ -94,6 +96,7 @@ class MenuBar
         return [
             'url' => $this->url,
             'icon' => $this->icon,
+            'windowPosition' => $this->windowPosition,
             'x' => $this->x,
             'y' => $this->y,
             'label' => $this->label,

--- a/tests/MenuBar/MenuBarTest.php
+++ b/tests/MenuBar/MenuBarTest.php
@@ -22,5 +22,6 @@ it('menubar with create', function () {
     $this->assertEquals('milwad', $menuBarArray['label']);
     $this->assertEquals('https://github.com/milwad-dev', $menuBarArray['url']);
     $this->assertEquals('nativephp.png', $menuBarArray['icon']);
+    $this->assertEquals('trayCenter', $menuBarArray['windowPosition']);
     $this->assertIsArray($menuBarArray['contextMenu']);
 });


### PR DESCRIPTION
Adds support for passing [positioner](https://github.com/jenslind/electron-positioner) 'position' strings such as `trayLeft` and `trayBottomCenter` to [menubar](https://github.com/maxogden/menubar) via the windowPosition key.

By adding the `HasPositioner` trait to MenuBar you may now set the tray browser window positioning, for eg:

`MenuBar::create()->center();`
`MenuBar::create()->trayRight();`

etc.

This is also dependent on https://github.com/NativePHP/electron-plugin/pull/15