### PR TITLE
Implement MenuBarDroppedFiles event

### DIFF
--- a/src/Events/MenuBar/MenuBarDroppedFiles.php
+++ b/src/Events/MenuBar/MenuBarDroppedFiles.php
@@ -12,6 +12,10 @@ class MenuBarDroppedFiles implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    public function __construct(public array $files = [])
+    {
+    }
+
     public function broadcastOn()
     {
         return [

--- a/src/Events/MenuBar/MenuBarDroppedFiles.php
+++ b/src/Events/MenuBar/MenuBarDroppedFiles.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Native\Laravel\Events\MenuBar;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MenuBarDroppedFiles implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}


### PR DESCRIPTION
This pull request implements a new Menubar event that triggers when files are dropped on top of the menu bar icon.
This pul request should pair with https://github.com/NativePHP/electron-plugin/pull/16.

# Todo

- [x] Path to dropped files should be added to Laravel event