### PR TITLE
Add hide window functionality

### DIFF
--- a/src/Events/Windows/WindowHidden.php
+++ b/src/Events/Windows/WindowHidden.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Native\Laravel\Events\Windows;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WindowHidden implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public string $id)
+    {
+        //
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Windows/WindowManager.php
+++ b/src/Windows/WindowManager.php
@@ -26,6 +26,13 @@ class WindowManager
         ]);
     }
 
+    public function hide($id = null)
+    {
+        return $this->client->post('window/hide', [
+            'id' => $id ?? $this->detectId(),
+        ]);
+    }
+
     public function current()
     {
         return (object) $this->client->get('window/current')->json();


### PR DESCRIPTION
While developing on linux, i noticed that running the Window::close() method exited the app entirely. This (and the electron plugin pr) will allow 'hiding' the app while keeping it running.
