### PR TITLE
Add withoutIcon method to Menubar class

### DIFF
--- a/src/MenuBar/MenuBar.php
+++ b/src/MenuBar/MenuBar.php
@@ -16,6 +16,8 @@ class MenuBar
 
     protected string $icon = '';
 
+    protected bool $withoutIcon = false;
+
     protected string $label = '';
 
     protected bool $onlyShowContextWindow = false;
@@ -43,6 +45,13 @@ class MenuBar
     public function icon(string $icon): self
     {
         $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function withoutIcon(bool $withoutIcon = true): self
+    {
+        $this->withoutIcon = $withoutIcon;
 
         return $this;
     }
@@ -94,6 +103,7 @@ class MenuBar
         return [
             'url' => $this->url,
             'icon' => $this->icon,
+            'withoutIcon' => $this->withoutIcon,
             'x' => $this->x,
             'y' => $this->y,
             'label' => $this->label,


### PR DESCRIPTION
# Situation
I want to create a text-only menubar application. Currently NativePHP cannot work with this.

## Solution
Added a 'withoutIcon' option when creating the menubar, so that a text-only menubar application can be created, without an icon.

Electron PR: https://github.com/NativePHP/electron-plugin/pull/18
