### PR TITLE
Add ability to exclude files and entire folders from built application

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -54,6 +54,17 @@ return [
     ],
 
     /**
+     * A list of files and folders that should be removed from the
+     * final app before it is bundled for production.
+     * You may use glob / wildcard patterns here.
+     */
+    'cleanup_exclude_files' => [
+        'content',
+        'storage/app/framework/{sessions,testing,cache}',
+        'storage/logs/laravel.log',
+    ],
+
+    /**
      * The NativePHP updater configuration.
      */
     'updater' => [

--- a/src/Commands/MinifyApplicationCommand.php
+++ b/src/Commands/MinifyApplicationCommand.php
@@ -86,26 +86,26 @@ class MinifyApplicationCommand extends Command
         }
     }
 
-    private function deleteDirectoryRecursive($dir)
+    private function deleteDirectoryRecursive(string $directory)
     {
-        if (! file_exists($dir)) {
+        if (! file_exists($directory)) {
             return true;
         }
 
-        if (! is_dir($dir)) {
-            return unlink($dir);
+        if (! is_dir($directory)) {
+            return unlink($directory);
         }
 
-        foreach (scandir($dir) as $item) {
+        foreach (scandir($directory) as $item) {
             if ($item == '.' || $item == '..') {
                 continue;
             }
 
-            if (! $this->deleteDirectoryRecursive($dir.'/'.$item)) {
+            if (! $this->deleteDirectoryRecursive($directory.'/'.$item)) {
                 return false;
             }
         }
 
-        return rmdir($dir);
+        return rmdir($directory);
     }
 }

--- a/src/Commands/MinifyApplicationCommand.php
+++ b/src/Commands/MinifyApplicationCommand.php
@@ -74,7 +74,7 @@ class MinifyApplicationCommand extends Command
 
             if (file_exists($fullPath)) {
                 if (is_dir($fullPath)) {
-                    $this->delete_directory_recursive($fullPath);
+                    $this->deleteDirectoryRecursive($fullPath);
                 } else {
                     array_map('unlink', glob($fullPath));
                 }
@@ -86,7 +86,7 @@ class MinifyApplicationCommand extends Command
         }
     }
 
-    private function delete_directory_recursive($dir)
+    private function deleteDirectoryRecursive($dir)
     {
         if (! file_exists($dir)) {
             return true;
@@ -101,7 +101,7 @@ class MinifyApplicationCommand extends Command
                 continue;
             }
 
-            if (! $this->delete_directory_recursive($dir.'/'.$item)) {
+            if (! $this->deleteDirectoryRecursive($dir.'/'.$item)) {
                 return false;
             }
         }

--- a/src/Commands/MinifyApplicationCommand.php
+++ b/src/Commands/MinifyApplicationCommand.php
@@ -74,7 +74,7 @@ class MinifyApplicationCommand extends Command
 
             if (file_exists($fullPath)) {
                 if (is_dir($fullPath)) {
-                    $this->delete_directory($fullPath);
+                    $this->delete_directory_recursive($fullPath);
                 } else {
                     array_map('unlink', glob($fullPath));
                 }
@@ -86,7 +86,7 @@ class MinifyApplicationCommand extends Command
         }
     }
 
-    private function delete_directory($dir)
+    private function delete_directory_recursive($dir)
     {
         if (! file_exists($dir)) {
             return true;
@@ -101,7 +101,7 @@ class MinifyApplicationCommand extends Command
                 continue;
             }
 
-            if (! $this->delete_directory($dir.'/'.$item)) {
+            if (! $this->delete_directory_recursive($dir.'/'.$item)) {
                 return false;
             }
         }

--- a/src/Commands/MinifyApplicationCommand.php
+++ b/src/Commands/MinifyApplicationCommand.php
@@ -86,7 +86,7 @@ class MinifyApplicationCommand extends Command
         }
     }
 
-    private function deleteDirectoryRecursive(string $directory)
+    private function deleteDirectoryRecursive(string $directory): void
     {
         if (! file_exists($directory)) {
             return true;
@@ -106,6 +106,6 @@ class MinifyApplicationCommand extends Command
             }
         }
 
-        return rmdir($directory);
+        rmdir($directory);
     }
 }

--- a/tests/Command/IgnoreFilesAndFoldersTest.php
+++ b/tests/Command/IgnoreFilesAndFoldersTest.php
@@ -1,0 +1,88 @@
+<?php
+
+it('will remove laravel.log by default before building', function () {
+    $logPath = 'resources/app/storage/logs';
+    $laravelLog = $logPath.'/laravel.log';
+
+    // Create a dummy copy of the file
+    if (! file_exists($logPath)) {
+        mkdir($logPath, 0755, true);
+    }
+    file_put_contents($laravelLog, 'TEST');
+
+    // Run the test
+    $this->artisan('native:minify resources/app');
+    $this->assertFalse(file_exists($laravelLog));
+
+    // Clean up after ourselves
+    if (file_exists($laravelLog)) {
+        unlink($laravelLog);
+    }
+    if (file_exists('resources/app/storage/logs')) {
+        rmdir('resources/app/storage/logs');
+    }
+    if (file_exists('resources/app/storage')) {
+        rmdir('resources/app/storage');
+    }
+    removeAppFolder();
+});
+
+it('will remove the content folder by default before building', function () {
+    $contentPath = 'resources/app/content';
+
+    // Create a dummy copy of the folder
+    if (! file_exists($contentPath)) {
+        mkdir($contentPath, 0755, true);
+    }
+
+    // Run the test
+    $this->artisan('native:minify resources/app');
+    $this->assertFalse(file_exists($contentPath));
+
+    // Clean up after ourselves
+    if (file_exists($contentPath)) {
+        unlink($contentPath);
+    }
+    removeAppFolder();
+});
+
+it('will remove only files that match a globbed path', function () {
+    $wildcardPath = 'resources/app/wildcardPath';
+    $yes1DeletePath = $wildcardPath.'/YES1.txt';
+    $yes2DeletePath = $wildcardPath.'/YES2.txt';
+    $noDeletePath = $wildcardPath.'/NO.txt';
+
+    config()->set('nativephp.cleanup_exclude_files', [$wildcardPath.'/YES*']);
+
+    // Create some dummy files
+    if (! file_exists($wildcardPath)) {
+        mkdir($wildcardPath, 0755, true);
+    }
+    file_put_contents($yes1DeletePath, 'PLEASE DELETE ME');
+    file_put_contents($yes2DeletePath, 'PLEASE DELETE ME TOO');
+    file_put_contents($noDeletePath, 'DO NOT DELETE ME');
+
+    // Run the test
+    $this->artisan('native:minify resources/app');
+    $this->assertFalse(file_exists($yes1DeletePath));
+    $this->assertFalse(file_exists($yes2DeletePath));
+    $this->assertTrue(file_exists($noDeletePath));
+
+    // Clean up after ourselves
+    foreach ([$yes1DeletePath, $yes2DeletePath, $noDeletePath] as $remove) {
+        if (file_exists($remove)) {
+            unlink($remove);
+        }
+    }
+    if (file_exists($wildcardPath)) {
+        rmdir($wildcardPath);
+    }
+    removeAppFolder();
+});
+
+function removeAppFolder()
+{
+    if (file_exists('resources/app')) {
+        rmdir('resources/app');
+    }
+}


### PR DESCRIPTION
As it stands right now, the `native:build` command takes your entire project folder and builds the application with it.

This may not be desirable as certain files may be unnecessary for the app to run, or may unintentionally leak sensitive information by being included.  

This PR allows for the blocking of individual files, folders, glob patterns, or wildcards (a user can mix and match) that they do not want being packaged.

I realize the tests are probably overly verbose but I couldn't think of a better way to generalize them.  Happy to refactor them if anyone can give me any pointers on a good way to do that.