### PR TITLE
fix: #175 'native:migrate fresh' command does not work

### DIFF
--- a/src/Commands/FreshCommand.php
+++ b/src/Commands/FreshCommand.php
@@ -3,19 +3,22 @@
 namespace Native\Laravel\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\Console\Migrations\FreshCommand as BaseFreshCommand;
 use Native\Laravel\NativeServiceProvider;
 
-class FreshCommand extends Command
+class FreshCommand extends BaseFreshCommand
 {
-    protected $description = 'Run the database migrations in the NativePHP development environment';
+    protected $description = 'Drop all tables and re-run all migrations in the NativePHP development environment';
 
-    protected $signature = 'native:migrate fresh';
+    protected $signature = 'native:migrate:fresh';
 
     public function handle()
     {
-        unlink(config('nativephp-internal.database_path'));
+        $nativeServiceProvider = new NativeServiceProvider($this->laravel);
 
-        (new NativeServiceProvider($this->laravel))->rewriteDatabase();
+        $nativeServiceProvider->removeDatabase();
+
+        $nativeServiceProvider->rewriteDatabase();
 
         $this->call('native:migrate');
     }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -4,6 +4,7 @@ namespace Native\Laravel;
 
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Support\Arr;
+use Native\Laravel\Commands\FreshCommand;
 use Native\Laravel\Commands\LoadPHPConfigurationCommand;
 use Native\Laravel\Commands\LoadStartupConfigurationCommand;
 use Native\Laravel\Commands\MigrateCommand;
@@ -20,6 +21,7 @@ class NativeServiceProvider extends PackageServiceProvider
             ->name('nativephp')
             ->hasCommands([
                 MigrateCommand::class,
+                FreshCommand::class,
                 MinifyApplicationCommand::class,
             ])
             ->hasConfigFile()
@@ -105,6 +107,21 @@ class NativeServiceProvider extends PackageServiceProvider
         ]]);
 
         config(['database.default' => 'nativephp']);
+    }
+
+    public function removeDatabase()
+    {
+        $databasePath = config('nativephp-internal.database_path');
+
+        if (config('app.debug')) {
+            $databasePath = database_path('nativephp.sqlite');
+
+            if (! file_exists($databasePath)) {
+                return;
+            }
+        }
+
+        unlink($databasePath);
     }
 
     protected function configureDisks(): void


### PR DESCRIPTION
Closes #175 

### Why
The previous implementation of `native:migrate fresh` command conflicted with the base `native:migrate` command implementation and showed the error described in the issue. 

### Changes
- Updated the `FreshCommand` implementation to extend it from the base `FreshCommand` of the Illuminate Console command and updated the signature to keep it similar to the base command. 
- Updated the `NativeServiceProvider` to add this new command. 