### PR TITLE
fix: 'native:db:seed' command not working

### DIFF
--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -8,6 +8,7 @@ use Native\Laravel\Commands\LoadPHPConfigurationCommand;
 use Native\Laravel\Commands\LoadStartupConfigurationCommand;
 use Native\Laravel\Commands\MigrateCommand;
 use Native\Laravel\Commands\MinifyApplicationCommand;
+use Native\Laravel\Commands\SeedDatabaseCommand;
 use Native\Laravel\Logging\LogWatcher;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -20,6 +21,7 @@ class NativeServiceProvider extends PackageServiceProvider
             ->name('nativephp')
             ->hasCommands([
                 MigrateCommand::class,
+                SeedDatabaseCommand::class,
                 MinifyApplicationCommand::class,
             ])
             ->hasConfigFile()


### PR DESCRIPTION
### Why
`php artisan native:db:seed` command was not working and showed the error:
![Screenshot 2023-08-29 at 3 20 06 AM](https://github.com/NativePHP/laravel/assets/831997/6f506e3c-a395-4791-8aed-6d8c3a50710d)


### Changes
- Added the `SeedDatabaseCommand` in the packages service provider so that the command is available.