### PR TITLE
Fix the issue that prevented setting the position on open windows

### DIFF
--- a/src/Windows/WindowManager.php
+++ b/src/Windows/WindowManager.php
@@ -42,7 +42,7 @@ class WindowManager
 
     public function position($x, $y, $animated = false, $id = null)
     {
-        $this->client->post('window/resize', [
+        $this->client->post('window/position', [
             'id' => $id ?? $this->detectId(),
             'x' => $x,
             'y' => $y,


### PR DESCRIPTION
The position method mistakenly made an API call to the resize endpoint. I just updated it to point to the correct endpoint. I've confirmed that this change results in the expected behavior.