### PR TITLE
Fix config commands not registered

### DIFF
--- a/src/Commands/MinifyApplicationCommand.php
+++ b/src/Commands/MinifyApplicationCommand.php
@@ -86,7 +86,7 @@ class MinifyApplicationCommand extends Command
         }
     }
 
-    private function deleteDirectoryRecursive(string $directory): void
+    private function deleteDirectoryRecursive(string $directory): bool
     {
         if (! file_exists($directory)) {
             return true;
@@ -106,6 +106,6 @@ class MinifyApplicationCommand extends Command
             }
         }
 
-        rmdir($directory);
+        return rmdir($directory);
     }
 }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -23,6 +23,8 @@ class NativeServiceProvider extends PackageServiceProvider
                 MigrateCommand::class,
                 SeedDatabaseCommand::class,
                 MinifyApplicationCommand::class,
+                LoadStartupConfigurationCommand::class,
+                LoadPHPConfigurationCommand::class,
             ])
             ->hasConfigFile()
             ->hasRoute('api')
@@ -38,13 +40,6 @@ class NativeServiceProvider extends PackageServiceProvider
         });
 
         if (config('nativephp-internal.running')) {
-            Artisan::starting(function ($artisan) {
-                $artisan->resolveCommands([
-                    LoadStartupConfigurationCommand::class,
-                    LoadPHPConfigurationCommand::class,
-                ]);
-            });
-
             $this->configureApp();
         }
     }


### PR DESCRIPTION
This PR fixes two tiny things, one of them being that values were being returned inside of the `MinifyApplicationCommand::deleteDirectoryRecursive` method.

And the other issue being one that is described in #168 and #160, this PR registers the `LoadStartupConfigurationCommand` and `LoadPHPConfigurationCommand` commands in the service provider's `configurePackage` method instead of dynamically resolving them later.

(These commands do get registered it seems, but they don't get registered *on time*. I assume this command is ran internally while they are not yet registered.)

Closes #168 