### PR TITLE
Fix PHP Fatal Error deleteDirectoryRecursive function in MinifyApplicationCommand

### DIFF
--- a/src/Commands/MinifyApplicationCommand.php
+++ b/src/Commands/MinifyApplicationCommand.php
@@ -86,7 +86,7 @@ class MinifyApplicationCommand extends Command
         }
     }
 
-    private function deleteDirectoryRecursive(string $directory): void
+    private function deleteDirectoryRecursive(string $directory): bool
     {
         if (! file_exists($directory)) {
             return true;
@@ -106,6 +106,6 @@ class MinifyApplicationCommand extends Command
             }
         }
 
-        rmdir($directory);
+        return rmdir($directory);
     }
 }


### PR DESCRIPTION
Fix for PHP Fatal error:  A void function must not return a value in src\Commands\MinifyApplicationCommand.php on line 92

