### PR TITLE
Add the reload() method to the WindowManager

### DIFF
--- a/src/Facades/Window.php
+++ b/src/Facades/Window.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void resize($width, $height, $id = null)
  * @method static void position($x, $y, $animated = false, $id = null)
  * @method static void alwaysOnTop($alwaysOnTop = true, $id = null)
+ * @method static void reload($id = null)
  */
 class Window extends Facade
 {

--- a/src/Windows/WindowManager.php
+++ b/src/Windows/WindowManager.php
@@ -71,4 +71,11 @@ class WindowManager
             'id' => $id ?? $this->detectId(),
         ]);
     }
+
+    public function reload($id = null): void
+    {
+        $this->client->post('window/reload', [
+            'id' => $id ?? $this->detectId(),
+        ]);
+    }
 }


### PR DESCRIPTION
This PR adds the `reload()` method to the `\Native\Laravel\Windows\WindowManager` class that calls the `window/reload` endpoint added to the Electron backend.