### PR TITLE
Fixed Tests

### DIFF
--- a/src/Windows/Window.php
+++ b/src/Windows/Window.php
@@ -272,6 +272,7 @@ class Window
             'fullscreenable' => $this->fullscreenable,
             'kiosk' => $this->kiosk,
             'autoHideMenuBar' => $this->autoHideMenuBar,
+            'transparent' => $this->transparent,
         ];
     }
 

--- a/tests/Http/Controller/DispatchEventFromAppControllerTest.php
+++ b/tests/Http/Controller/DispatchEventFromAppControllerTest.php
@@ -19,15 +19,16 @@ it('dispatches an event', function () {
     Event::assertDispatched(TestEvent::class);
 });
 
-it('dispatches no event in case it does not exist', function () {
+// Since 45b7ccfcb86ebf35be35c1eb7fbb9f05a224448f nonexistent classes are handled as string events
+it('dispatches a string event', function () {
     Event::fake();
 
     $this->withoutMiddleware()
         ->post('_native/api/events', [
-            'event' => InvalidEvent::class,
+            'event' => 'some-event-that-is-no-class',
         ]);
 
-    Event::assertNotDispatched(InvalidEvent::class);
+    Event::assertDispatched('some-event-that-is-no-class');
 });
 
 it('passes the payload to the event', function () {

--- a/tests/Windows/WindowTest.php
+++ b/tests/Windows/WindowTest.php
@@ -1,8 +1,12 @@
 <?php
 
 use Native\Laravel\Facades\Window;
+use Native\Laravel\Windows\Window as WindowClass;
 
 it('test window', function () {
+    Window::shouldReceive('open')
+        ->andReturn(new WindowClass('main'));
+
     $window = Window::open()
         ->id('main')
         ->title('milwad')
@@ -38,12 +42,15 @@ it('test window', function () {
     expect($windowArray['minimizable'])->toBeTrue();
     expect($windowArray['maximizable'])->toBeTrue();
     expect($windowArray['closable'])->toBeTrue();
-    expect($windowArray['fullscreen'])->toBeFalse();
+    expect($windowArray['fullscreen'])->toBeTrue();
     expect($windowArray['kiosk'])->toBeFalse();
     expect($windowArray['autoHideMenuBar'])->toBeTrue();
 });
 
 it('test title bar for window', function () {
+    Window::shouldReceive('open')
+        ->andReturn(new WindowClass('main'));
+
     $window = Window::open()
         ->titleBarHidden();
 
@@ -59,6 +66,9 @@ it('test title bar for window', function () {
 });
 
 it('test for trafficLightPosition in window', function () {
+    Window::shouldReceive('open')
+        ->andReturn(new WindowClass('main'));
+
     $window = Window::open()
         ->trafficLightPosition(10, 10);
 
@@ -78,10 +88,13 @@ it('test for trafficLightPosition in window', function () {
 });
 
 it('test for invisibleFrameless in window', function () {
+    Window::shouldReceive('open')
+        ->andReturn(new WindowClass('main'));
+
     $window = Window::open()->invisibleFrameless();
     $windowArray = $window->toArray();
 
-    expect($windowArray['frame'])->toBeTrue();
+    expect($windowArray['frame'])->toBeFalse();
     expect($windowArray['transparent'])->toBeTrue();
     expect($windowArray['focusable'])->toBeFalse();
     expect($windowArray['hasShadow'])->toBeFalse();


### PR DESCRIPTION
- Some tests failed due to new features.
- A few assertions were incorrect.
- `Native\Laravel\Windows\Window::toArray()` now contains `transparent`
- Tests that call `Window::open()` were changed to not use PendingOpenWindow as it causes failing API calls