### PR TITLE
Feature: Broadcast custom Events on IPC

### DIFF
--- a/src/Events/EventWatcher.php
+++ b/src/Events/EventWatcher.php
@@ -21,12 +21,18 @@ class EventWatcher
 
             $channels = $event->broadcastOn();
 
+            // Only events dispatched on the nativephp channel
             if(! in_array('nativephp', $channels)) {
                 return;
             }
 
+            // Only post custom events to broadcasting endpoint
+            if(str_starts_with($eventName ,'Native\\Laravel\\Events')) {
+                return;
+            }
+
             $this->client->post('broadcast', [
-                'event' => $eventName,
+                'event' => "\\{$eventName}",
                 'payload' => $event
             ]);
         });

--- a/src/Events/EventWatcher.php
+++ b/src/Events/EventWatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Native\Laravel\Events;
+
+use Illuminate\Support\Facades\Event;
+use Native\Laravel\Client\Client;
+
+class EventWatcher
+{
+    public function __construct(protected Client $client) {}
+
+    public function register(): void
+    {
+        Event::listen('*', function (string $eventName, array $data) {
+
+            $event = $data[0] ?? null;
+
+            if (! method_exists($event, 'broadcastOn')) {
+                return;
+            }
+
+            $channels = $event->broadcastOn();
+
+            if(! in_array('nativephp', $channels)) {
+                return;
+            }
+
+            $this->client->post('debug/broadcast', ['event' => $event]);
+        });
+    }
+}

--- a/src/Events/EventWatcher.php
+++ b/src/Events/EventWatcher.php
@@ -25,7 +25,10 @@ class EventWatcher
                 return;
             }
 
-            $this->client->post('debug/broadcast', ['event' => $event]);
+            $this->client->post('broadcast', [
+                'event' => $eventName,
+                'payload' => $event
+            ]);
         });
     }
 }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -11,6 +11,7 @@ use Native\Laravel\Commands\MigrateCommand;
 use Native\Laravel\Commands\MinifyApplicationCommand;
 use Native\Laravel\Commands\SeedDatabaseCommand;
 use Native\Laravel\Logging\LogWatcher;
+use Native\Laravel\Events\EventWatcher;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -60,6 +61,8 @@ class NativeServiceProvider extends PackageServiceProvider
         if (config('app.debug')) {
             app(LogWatcher::class)->register();
         }
+
+        app(EventWatcher::class)->register();
 
         $this->rewriteStoragePath();
 


### PR DESCRIPTION
# Summary

This PR implements a `api/broadcasting` endpoint to handle all custom events dispatched on the `nativephp` channel. (See https://github.com/NativePHP/laravel/issues/295#issuecomment-2333816131)

Whenever a Laravel event is dispatched on the `nativephp` channel, a `native-event` event will be dispached on IPC so we can both listen to these events on the frontend using `ipcRenderer.on('native-event')` and using Livewire listeners without using a separate websocket server.

Please also check out https://github.com/NativePHP/electron-plugin/pull/37 which implements the endpoint in the Electron backend

For example, whenever the following event is dispatched:

``` php
class FooBar
{
    use Dispatchable;

    public $foo = 'Bar';

    public function broadcastOn(): array
    {
        return [
            new Channel('nativephp'),
        ];
    }
}
```

You may listen to it within Livewire using a listener:

``` php
#[On('native:\App\Events\FooBar')]
public function listenOnIpc(FooBar $event)
{
    // dd($event);
}
```

Or directly int the frontend using the `ipcRenderer`

``` html

<!-- 
Assuming you have ipcRenderer attached to the window scope in your bundle:
window.ipcRenderer = require('electron').ipcRenderer
-->

<script>
    window.ipcRenderer.on('native-event', (native, { event, payload }) => {

        console.dir(event)
        console.dir(payload)
    })
</script>

```

## For your consideration

1. I'm using the existing `native-event` so all events are automatically forwarded to Livewire. I'm unsure about the naming of this, strictly speaking this isn't a Native event, but rather a custom one.

2. I've looked around for a existing path to testing this, but it seems similar features (like the debug endpoint) aren't covered. If you wan't me to cover this PR with tests I'll have to do some more digging. I'm not very experienced with jest & TS

3. While exploring the codebase I found an existing `notifyLaravel` function in the electron plugins' `utils.ts`. It looks like this function doesn't emit events to any menubar window like was recently added to the debug enpoint. Should I create a separate issue for this?

## Closing

I've got all this working locally without issues. If you'd like me to change anything please let me know and I'll update this asap 👍🏻 