### PR TITLE
child process - sanity tests and tweaks

### DIFF
--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -12,7 +12,7 @@ class ChildProcess
 
     public function __construct(protected Client $client) {}
 
-    public function start(string $alias, string|array $cmd, ?string $cwd = null, ?array $env = null): self
+    public function start(string|array $cmd, string $alias, ?string $cwd = null, ?array $env = null): self
     {
         $this->alias = $alias;
 
@@ -34,11 +34,11 @@ class ChildProcess
         return $this;
     }
 
-    public function artisan(string $alias, string|array $cmd, ?array $env = null): self
+    public function artisan(string|array $cmd, string $alias, ?array $env = null): self
     {
         $cmd = [PHP_BINARY, 'artisan', ...(array) $cmd];
 
-        return $this->start($alias, $cmd, env: $env);
+        return $this->start($cmd, $alias, env: $env);
     }
 
     public function stop(string $alias): void
@@ -48,11 +48,11 @@ class ChildProcess
         ])->json();
     }
 
-    public function message(string $alias, mixed $message): void
+    public function message(mixed $message, string $alias): void
     {
         $this->client->post('child-process/message', [
-            'alias' => $alias,
             'message' => json_encode($message),
+            'alias' => $alias,
         ])->json();
     }
 }

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -28,6 +28,31 @@ class ChildProcess
         return $this;
     }
 
+    public function artisan(string $alias, array $cmd, ?array $env = null): object
+    {
+        $cmd = array_merge([PHP_BINARY, 'artisan'], $cmd);
+
+        return $this->start(
+            $alias,
+            $cmd,
+            base_path(),
+            $env
+        );
+
+        $this->alias = $alias;
+
+        $cwd = $cwd ?? base_path();
+
+        $this->process = $this->client->post('child-process/start', [
+            'alias' => $alias,
+            'cmd' => $cmd,
+            'cwd' => $cwd,
+            'env' => $env,
+        ])->json();
+
+        return $this;
+    }
+
     public function stop(string $alias): void
     {
         $this->client->post('child-process/stop', [

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -16,10 +16,12 @@ class ChildProcess
     {
         $this->alias = $alias;
 
+        $cwd = $cwd ?? base_path();
+
         $this->process = $this->client->post('child-process/start', [
             'alias' => $alias,
             'cmd' => $cmd,
-            'cwd' => base_path(),
+            'cwd' => $cwd,
             'env' => $env,
         ])->json();
 

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -6,16 +6,10 @@ use Native\Laravel\Client\Client;
 
 class ChildProcess
 {
-    private string $alias;
-
-    private ?array $process;
-
     public function __construct(protected Client $client) {}
 
     public function start(string|array $cmd, string $alias, ?string $cwd = null, ?array $env = null): self
     {
-        $this->alias = $alias;
-
         $cwd = $cwd ?? base_path();
 
         $cmd = is_iterable($cmd)
@@ -24,7 +18,7 @@ class ChildProcess
             // when a string is passed, explode it on the space
             : array_values(array_filter(explode(' ', $cmd)));
 
-        $this->process = $this->client->post('child-process/start', [
+        $this->client->post('child-process/start', [
             'alias' => $alias,
             'cmd' => $cmd,
             'cwd' => $cwd,

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -112,7 +112,7 @@ class ChildProcess
         return $this;
     }
 
-    private function fromRuntimeProcess($process): static
+    protected function fromRuntimeProcess($process): static
     {
         if (isset($process['pid'])) {
             $this->pid = $process['pid'];

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -50,15 +50,14 @@ class ChildProcess
 
         return $hydrated;
     }
-        
+
     public function start(
-        string|array $cmd
+        string|array $cmd,
         string $alias,
         ?string $cwd = null,
         ?array $env = null,
         bool $persistent = false
     ): static {
-        $cwd = $cwd ?? base_path();
 
         if (is_string($cmd)) {
             // When a string is passed, explode it on the space

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -12,11 +12,10 @@ class ChildProcess
     {
         $cwd = $cwd ?? base_path();
 
-        $cmd = is_iterable($cmd)
-            // when an array is passed, escape spaces for each item
-            ? array_map(fn ($a) => str_replace(' ', '\ ', $a), $cmd)
-            // when a string is passed, explode it on the space
-            : array_values(array_filter(explode(' ', $cmd)));
+        if (is_string($cmd)) {
+            // When a string is passed, explode it on the space
+            $cmd = array_values(array_filter(explode(' ', $cmd)));
+        }
 
         $this->client->post('child-process/start', [
             'alias' => $alias,

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -61,7 +61,7 @@ class ChildProcess
 
         $process = $this->client->post('child-process/start', [
             'alias' => $alias,
-            'cmd' => $this->explodeCommand($cmd),
+            'cmd' => (array) $cmd,
             'cwd' => $cwd ?? base_path(),
             'env' => $env,
             'persistent' => $persistent,
@@ -72,14 +72,14 @@ class ChildProcess
 
     public function php(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
-        $cmd = [PHP_BINARY, ...$this->explodeCommand($cmd)];
+        $cmd = [PHP_BINARY, ...(array) $cmd];
 
         return $this->start($cmd, $alias, env: $env, persistent: $persistent);
     }
 
     public function artisan(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
-        $cmd = ['artisan', ...$this->explodeCommand($cmd)];
+        $cmd = ['artisan', ...(array) $cmd];
 
         return $this->php($cmd, $alias, env: $env, persistent: $persistent);
     }
@@ -125,14 +125,5 @@ class ChildProcess
         }
 
         return $this;
-    }
-
-    private function explodeCommand(string|array $cmd): array
-    {
-        if (is_iterable($cmd)) {
-            return $cmd;
-        }
-
-        return array_values(array_filter(explode(' ', $cmd)));
     }
 }

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -79,9 +79,9 @@ class ChildProcess
 
     public function artisan(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
-        $cmd = [PHP_BINARY, 'artisan', ...$this->explodeCommand($cmd)];
+        $cmd = ['artisan', ...$this->explodeCommand($cmd)];
 
-        return $this->start($cmd, $alias, env: $env, persistent: $persistent);
+        return $this->php($cmd, $alias, env: $env, persistent: $persistent);
     }
 
     public function stop(?string $alias = null): void

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -8,7 +8,7 @@ class ChildProcess
 {
     public function __construct(protected Client $client) {}
 
-    public function start(string|array $cmd, string $alias, ?string $cwd = null, ?array $env = null): self
+    public function start(string|array $cmd, string $alias, ?string $cwd = null, ?array $env = null, ?bool $persistent = false): self
     {
         $cwd = $cwd ?? base_path();
 
@@ -22,16 +22,17 @@ class ChildProcess
             'cmd' => $cmd,
             'cwd' => $cwd,
             'env' => $env,
+            'persistent' => $persistent,
         ])->json();
 
         return $this;
     }
 
-    public function artisan(string|array $cmd, string $alias, ?array $env = null): self
+    public function artisan(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
         $cmd = [PHP_BINARY, 'artisan', ...(array) $cmd];
 
-        return $this->start($cmd, $alias, env: $env);
+        return $this->start($cmd, $alias, env: $env, persistent: $persistent);
     }
 
     public function stop(string $alias): void

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -12,7 +12,7 @@ class ChildProcess
 
     public function __construct(protected Client $client) {}
 
-    public function start(string $alias, string|array $cmd, ?string $cwd = null, ?array $env = null): object
+    public function start(string $alias, string|array $cmd, ?string $cwd = null, ?array $env = null): self
     {
         $this->alias = $alias;
 
@@ -34,7 +34,7 @@ class ChildProcess
         return $this;
     }
 
-    public function artisan(string $alias, string|array $cmd, ?array $env = null): object
+    public function artisan(string $alias, string|array $cmd, ?array $env = null): self
     {
         $cmd = [PHP_BINARY, 'artisan', ...(array) $cmd];
 

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -68,7 +68,7 @@ class ChildProcess
         $process = $this->client->post('child-process/start', [
             'alias' => $alias,
             'cmd' => $cmd,
-            'cwd' => $cwd,
+            'cwd' => $cwd ?? base_path(),
             'env' => $env,
             'persistent' => $persistent,
         ])->json();

--- a/src/Facades/ChildProcess.php
+++ b/src/Facades/ChildProcess.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Native\Laravel\ChildProcess start(string|array $cmd, string $alias, string $cwd = null, array $env = null, bool $persistent = false)
  * @method static \Native\Laravel\ChildProcess php(string|array $cmd, string $alias, array $env = null, bool $persistent = false)
  * @method static \Native\Laravel\ChildProcess artisan(string|array $cmd, string $alias, array $env = null, bool $persistent = false)
- * @method static \Native\Laravel\ChildProcess void stop(string $alias = null)
+ * @method static void stop(string $alias = null)
  */
 class ChildProcess extends Facade
 {

--- a/src/Facades/ChildProcess.php
+++ b/src/Facades/ChildProcess.php
@@ -3,6 +3,7 @@
 namespace Native\Laravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Native\Laravel\ChildProcess as Implement;
 
 /**
  * @method static \Native\Laravel\ChildProcess[] all()
@@ -18,6 +19,8 @@ class ChildProcess extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \Native\Laravel\ChildProcess::class;
+        self::clearResolvedInstance(Implement::class);
+
+        return Implement::class;
     }
 }

--- a/src/Facades/ChildProcess.php
+++ b/src/Facades/ChildProcess.php
@@ -6,11 +6,13 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static \Native\Laravel\ChildProcess[] all()
- * @method static \Native\Laravel\ChildProcess get(string $alias)
+ * @method static \Native\Laravel\ChildProcess get(string $alias = null)
  * @method static \Native\Laravel\ChildProcess message(string $message, string $alias = null)
- * @method static \Native\Laravel\ChildProcess restart(string $alias)
- * @method static \Native\Laravel\ChildProcess start(string $alias, array $cmd, string $cwd = null, array $env = null, bool $persistent = false)
- * @method static void stop(string $alias)
+ * @method static \Native\Laravel\ChildProcess restart(string $alias = null)
+ * @method static \Native\Laravel\ChildProcess start(string|array $cmd, string $alias, string $cwd = null, array $env = null, bool $persistent = false)
+ * @method static \Native\Laravel\ChildProcess php(string|array $cmd, string $alias, array $env = null, bool $persistent = false)
+ * @method static \Native\Laravel\ChildProcess artisan(string|array $cmd, string $alias, array $env = null, bool $persistent = false)
+ * @method static \Native\Laravel\ChildProcess void stop(string $alias = null)
  */
 class ChildProcess extends Facade
 {

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -26,7 +26,7 @@ it('can start a artisan command', function () {
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
                $request['alias'] === 'some-alias' &&
-               $request['cmd'] === [str_replace(' ', '\ ', PHP_BINARY), 'artisan', 'foo:bar'] &&
+               $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar'] &&
                $request['cwd'] === base_path() &&
                $request['env'] === ['baz' => 'zah'];
     });
@@ -44,10 +44,10 @@ it('accepts either a string or a array as start command argument', function () {
 
 it('accepts either a string or a array as artisan command argument', function () {
     ChildProcess::artisan('foo:bar', 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === [str_replace(' ', '\ ', PHP_BINARY), 'artisan', 'foo:bar']);
+    Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar']);
 
     ChildProcess::artisan(['foo:baz'], 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === [str_replace(' ', '\ ', PHP_BINARY), 'artisan', 'foo:baz']);
+    Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:baz']);
 });
 
 it('sets the cwd to the base path if none was given', function () {
@@ -61,11 +61,6 @@ it('sets the cwd to the base path if none was given', function () {
 it('filters double spaces when exploding a command string', function () {
     ChildProcess::start('foo bar  baz      bak', 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'bar', 'baz', 'bak']);
-});
-
-it('escapes spaces when passing a command array', function () {
-    ChildProcess::start(['path/to/some executable with spaces.sh', '--foo', '--bar'], 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['path/to/some\ executable\ with\ spaces.sh', '--foo', '--bar']);
 });
 
 it('can stop a child process', function () {

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -20,11 +20,23 @@ it('can start a child process', function () {
     });
 });
 
-it('can start a artisan command')->todo();
+it('can start a artisan command', function () {
+    ChildProcess::artisan('some-alias', ['foo:bar'], ['baz' => 'zah']);
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/child-process/start' &&
+               $request['alias'] === 'some-alias' &&
+               $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar'] &&
+               $request['cwd'] === base_path() &&
+               $request['env'] === ['baz' => 'zah'];
+    });
+});
 
 it('can mark the process as persistent')->todo();
 
-it('accepts either a string or a array as command input')->todo();
+it('start method accepts either a string or a array as command input')->todo();
+
+it('artisan method accepts either a string or a array as command input')->todo();
 
 it('sets the cwd to the base path if none was given', function () {
     ChildProcess::start('some-alias', ['foo', 'bar'], cwd: 'path/to/dir');

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -32,7 +32,7 @@ it('can start a child process', function () {
 });
 
 it('can start a php command', function () {
-    ChildProcess::artisan("-r 'sleep(5);'", 'some-alias', ['baz' => 'zah']);
+    ChildProcess::php("-r 'sleep(5);'", 'some-alias', ['baz' => 'zah']);
 
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
@@ -41,15 +41,15 @@ it('can start a php command', function () {
                $request['cwd'] === base_path() &&
                $request['env'] === ['baz' => 'zah'];
     });
-})->todo();
+});
 
 it('can start a artisan command', function () {
-    ChildProcess::artisan('foo:bar', 'some-alias', ['baz' => 'zah']);
+    ChildProcess::artisan('foo:bar --verbose', 'some-alias', ['baz' => 'zah']);
 
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
                $request['alias'] === 'some-alias' &&
-               $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar'] &&
+               $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar', '--verbose'] &&
                $request['cwd'] === base_path() &&
                $request['env'] === ['baz' => 'zah'];
     });
@@ -64,12 +64,12 @@ it('accepts either a string or a array as start command argument', function () {
 });
 
 it('accepts either a string or a array as php command argument', function () {
-    ChildProcess::artisan(" 'sleep(5);'", 'some-alias');
+    ChildProcess::php("-r 'sleep(5);'", 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
 
     ChildProcess::artisan(['-r', "'sleep(5);'"], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
-})->todo();
+});
 
 it('accepts either a string or a array as artisan command argument', function () {
     ChildProcess::artisan('foo:bar', 'some-alias');
@@ -119,7 +119,7 @@ it('can mark a process as persistent', function () {
 it('can mark a php command as persistent', function () {
     ChildProcess::php("-r 'sleep(5);'", 'some-alias', persistent: true);
     Http::assertSent(fn (Request $request) => $request['persistent'] === true);
-})->todo();
+});
 
 it('can mark a artisan command as persistent', function () {
     ChildProcess::artisan('foo:bar', 'some-alias', persistent: true);

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -20,6 +20,18 @@ it('can start a child process', function () {
     });
 });
 
+it('can start a php command', function () {
+    ChildProcess::artisan("-r 'sleep(5);'", 'some-alias', ['baz' => 'zah']);
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/child-process/start' &&
+               $request['alias'] === 'some-alias' &&
+               $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"] &&
+               $request['cwd'] === base_path() &&
+               $request['env'] === ['baz' => 'zah'];
+    });
+});
+
 it('can start a artisan command', function () {
     ChildProcess::artisan('foo:bar', 'some-alias', ['baz' => 'zah']);
 
@@ -38,6 +50,14 @@ it('accepts either a string or a array as start command argument', function () {
 
     ChildProcess::start(['foo', 'baz'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'baz']);
+});
+
+it('accepts either a string or a array as php command argument', function () {
+    ChildProcess::artisan(" 'sleep(5);'", 'some-alias');
+    Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
+
+    ChildProcess::artisan(['-r', "'sleep(5);'"], 'some-alias');
+    Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
 });
 
 it('accepts either a string or a array as artisan command argument', function () {
@@ -82,6 +102,11 @@ it('can send messages to a child process', function () {
 
 it('can mark a process as persistent', function () {
     ChildProcess::start('foo bar', 'some-alias', persistent: true);
+    Http::assertSent(fn (Request $request) => $request['persistent'] === true);
+});
+
+it('can mark a php command as persistent', function () {
+    ChildProcess::php("-r 'sleep(5);'", 'some-alias', persistent: true);
     Http::assertSent(fn (Request $request) => $request['persistent'] === true);
 });
 

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -25,7 +25,7 @@ it('can start a child process', function () {
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
                $request['alias'] === 'some-alias' &&
-               $request['cmd'] === ['foo', 'bar'] &&
+               $request['cmd'] === ['foo bar'] &&
                $request['cwd'] === 'path/to/dir' &&
                $request['env'] === ['baz' => 'zah'];
     });
@@ -37,7 +37,7 @@ it('can start a php command', function () {
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
                $request['alias'] === 'some-alias' &&
-               $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"] &&
+               $request['cmd'] === [PHP_BINARY, "-r 'sleep(5);'"] &&
                $request['cwd'] === base_path() &&
                $request['env'] === ['baz' => 'zah'];
     });
@@ -49,7 +49,7 @@ it('can start a artisan command', function () {
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
                $request['alias'] === 'some-alias' &&
-               $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar', '--verbose'] &&
+               $request['cmd'] === [PHP_BINARY, 'artisan', 'foo:bar --verbose'] &&
                $request['cwd'] === base_path() &&
                $request['env'] === ['baz' => 'zah'];
     });
@@ -57,7 +57,7 @@ it('can start a artisan command', function () {
 
 it('accepts either a string or a array as start command argument', function () {
     ChildProcess::start('foo bar', 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'bar']);
+    Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo bar']);
 
     ChildProcess::start(['foo', 'baz'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'baz']);
@@ -65,9 +65,9 @@ it('accepts either a string or a array as start command argument', function () {
 
 it('accepts either a string or a array as php command argument', function () {
     ChildProcess::php("-r 'sleep(5);'", 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
+    Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, "-r 'sleep(5);'"]);
 
-    ChildProcess::artisan(['-r', "'sleep(5);'"], 'some-alias');
+    ChildProcess::php(['-r', "'sleep(5);'"], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
 });
 
@@ -85,11 +85,6 @@ it('sets the cwd to the base path if none was given', function () {
 
     ChildProcess::start(['foo', 'bar'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cwd'] === base_path());
-});
-
-it('filters double spaces when exploding a command string', function () {
-    ChildProcess::start('foo bar  baz      bak', 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'bar', 'baz', 'bak']);
 });
 
 it('can stop a child process', function () {

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -20,7 +20,9 @@ it('can start a child process', function () {
     });
 });
 
-it('can start a artisan command', function () {})->todo();
+it('can start a artisan command')->todo();
+
+it('can mark the process as persistent')->todo();
 
 it('accepts either a string or a array as command input')->todo();
 

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -2,10 +2,21 @@
 
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Mockery;
+use Native\Laravel\ChildProcess as ChildProcessImplement;
+use Native\Laravel\Client\Client;
 use Native\Laravel\Facades\ChildProcess;
 
 beforeEach(function () {
     Http::fake();
+
+    $mock = Mockery::mock(ChildProcessImplement::class, [resolve(Client::class)])
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $this->instance(ChildProcessImplement::class, $mock->allows([
+        'fromRuntimeProcess' => $mock,
+    ]));
 });
 
 it('can start a child process', function () {
@@ -30,7 +41,7 @@ it('can start a php command', function () {
                $request['cwd'] === base_path() &&
                $request['env'] === ['baz' => 'zah'];
     });
-});
+})->todo();
 
 it('can start a artisan command', function () {
     ChildProcess::artisan('foo:bar', 'some-alias', ['baz' => 'zah']);
@@ -58,7 +69,7 @@ it('accepts either a string or a array as php command argument', function () {
 
     ChildProcess::artisan(['-r', "'sleep(5);'"], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === [PHP_BINARY, '-r', "'sleep(5);'"]);
-});
+})->todo();
 
 it('accepts either a string or a array as artisan command argument', function () {
     ChildProcess::artisan('foo:bar', 'some-alias');
@@ -96,7 +107,7 @@ it('can send messages to a child process', function () {
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/message' &&
                $request['alias'] === 'some-alias' &&
-               $request['message'] === '"some-message"';
+               $request['message'] === 'some-message';
     });
 });
 
@@ -108,7 +119,7 @@ it('can mark a process as persistent', function () {
 it('can mark a php command as persistent', function () {
     ChildProcess::php("-r 'sleep(5);'", 'some-alias', persistent: true);
     Http::assertSent(fn (Request $request) => $request['persistent'] === true);
-});
+})->todo();
 
 it('can mark a artisan command as persistent', function () {
     ChildProcess::artisan('foo:bar', 'some-alias', persistent: true);

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Native\Laravel\Facades\ChildProcess;
+
+beforeEach(function () {
+    Http::fake();
+});
+
+it('can start a child process', function () {
+    ChildProcess::start('some-alias', ['foo', 'bar'], 'path/to/dir', ['baz' => 'zah']);
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/child-process/start' &&
+               $request['alias'] === 'some-alias' &&
+               $request['cmd'] === ['foo', 'bar'] &&
+               $request['cwd'] === 'path/to/dir' &&
+               $request['env'] === ['baz' => 'zah'];
+    });
+});
+
+it('can start a artisan command', function () {})->todo();
+
+it('accepts either a string or a array as command input')->todo();
+
+it('sets the cwd to the base path if none was given', function () {
+    ChildProcess::start('some-alias', ['foo', 'bar'], cwd: 'path/to/dir');
+    Http::assertSent(fn (Request $request) => $request['cwd'] === 'path/to/dir');
+
+    ChildProcess::start('some-alias', ['foo', 'bar']);
+    Http::assertSent(fn (Request $request) => $request['cwd'] === base_path());
+});
+
+it('can stop a child process', function () {
+    ChildProcess::stop('some-alias');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/child-process/stop' &&
+               $request['alias'] === 'some-alias';
+    });
+});
+
+it('can send messages to a child process', function () {
+    ChildProcess::message('some-alias', 'some-message');
+
+    Http::assertSent(function (Request $request) {
+        return $request->url() === 'http://localhost:4000/api/child-process/message' &&
+               $request['alias'] === 'some-alias' &&
+               $request['message'] === '"some-message"';
+    });
+});

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -32,8 +32,6 @@ it('can start a artisan command', function () {
     });
 });
 
-it('can mark the process as persistent')->todo();
-
 it('accepts either a string or a array as start command argument', function () {
     ChildProcess::start('foo bar', 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'bar']);
@@ -80,4 +78,19 @@ it('can send messages to a child process', function () {
                $request['alias'] === 'some-alias' &&
                $request['message'] === '"some-message"';
     });
+});
+
+it('can mark a process as persistent', function () {
+    ChildProcess::start('foo bar', 'some-alias', persistent: true);
+    Http::assertSent(fn (Request $request) => $request['persistent'] === true);
+});
+
+it('can mark a artisan command as persistent', function () {
+    ChildProcess::artisan('foo:bar', 'some-alias', persistent: true);
+    Http::assertSent(fn (Request $request) => $request['persistent'] === true);
+});
+
+it('marks the process as non-persistent by default', function () {
+    ChildProcess::start('foo bar', 'some-alias');
+    Http::assertSent(fn (Request $request) => $request['persistent'] === false);
 });

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -9,7 +9,7 @@ beforeEach(function () {
 });
 
 it('can start a child process', function () {
-    ChildProcess::start('some-alias', 'foo bar', 'path/to/dir', ['baz' => 'zah']);
+    ChildProcess::start('foo bar', 'some-alias', 'path/to/dir', ['baz' => 'zah']);
 
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
@@ -21,7 +21,7 @@ it('can start a child process', function () {
 });
 
 it('can start a artisan command', function () {
-    ChildProcess::artisan('some-alias', 'foo:bar', ['baz' => 'zah']);
+    ChildProcess::artisan('foo:bar', 'some-alias', ['baz' => 'zah']);
 
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/start' &&
@@ -35,36 +35,36 @@ it('can start a artisan command', function () {
 it('can mark the process as persistent')->todo();
 
 it('accepts either a string or a array as start command argument', function () {
-    ChildProcess::start('some-alias', 'foo bar');
+    ChildProcess::start('foo bar', 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'bar']);
 
-    ChildProcess::start('some-alias', ['foo', 'baz']);
+    ChildProcess::start(['foo', 'baz'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'baz']);
 });
 
 it('accepts either a string or a array as artisan command argument', function () {
-    ChildProcess::artisan('some-alias', 'foo:bar');
+    ChildProcess::artisan('foo:bar', 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === [str_replace(' ', '\ ', PHP_BINARY), 'artisan', 'foo:bar']);
 
-    ChildProcess::artisan('some-alias', ['foo:baz']);
+    ChildProcess::artisan(['foo:baz'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === [str_replace(' ', '\ ', PHP_BINARY), 'artisan', 'foo:baz']);
 });
 
 it('sets the cwd to the base path if none was given', function () {
-    ChildProcess::start('some-alias', ['foo', 'bar'], cwd: 'path/to/dir');
+    ChildProcess::start(['foo', 'bar'], 'some-alias', cwd: 'path/to/dir');
     Http::assertSent(fn (Request $request) => $request['cwd'] === 'path/to/dir');
 
-    ChildProcess::start('some-alias', ['foo', 'bar']);
+    ChildProcess::start(['foo', 'bar'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cwd'] === base_path());
 });
 
 it('filters double spaces when exploding a command string', function () {
-    ChildProcess::start('some-alias', 'foo bar  baz      bak');
+    ChildProcess::start('foo bar  baz      bak', 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'bar', 'baz', 'bak']);
 });
 
 it('escapes spaces when passing a command array', function () {
-    ChildProcess::start('some-alias', ['path/to/some executable with spaces.sh', '--foo', '--bar']);
+    ChildProcess::start(['path/to/some executable with spaces.sh', '--foo', '--bar'], 'some-alias');
     Http::assertSent(fn (Request $request) => $request['cmd'] === ['path/to/some\ executable\ with\ spaces.sh', '--foo', '--bar']);
 });
 
@@ -78,7 +78,7 @@ it('can stop a child process', function () {
 });
 
 it('can send messages to a child process', function () {
-    ChildProcess::message('some-alias', 'some-message');
+    ChildProcess::message('some-message', 'some-alias');
 
     Http::assertSent(function (Request $request) {
         return $request->url() === 'http://localhost:4000/api/child-process/message' &&


### PR DESCRIPTION
Builds on #389 

I started adding some tests. Will add some extra things to the ChildProcess api if that's okay with you @simonhamp.

- [x] Stub out tests
- [x] Set a `cwd` default if none was given
- [x] Add a `ChildProcess::artisan()` convenience method
- [x] Provide a way to make processes restart when they exit
- [x] Make sure the `cmd` argument accepts either a string or a array
- [x] Double check argument order to be consistent with other api's