### PR TITLE
Add exception handler

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -2,7 +2,8 @@
 
 namespace Native\Laravel\Exceptions;
 
-class Handler extends \Illuminate\Foundation\Exceptions\Handler {
+class Handler extends \Illuminate\Foundation\Exceptions\Handler
+{
     protected $internalDontReport = [];
 
     public function register(): void

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Native\Laravel\Exceptions;
+
+class Handler extends \Illuminate\Foundation\Exceptions\Handler {
+    protected $internalDontReport = [];
+
+    public function register(): void
+    {
+        $this->reportable(function (\Throwable $e) {
+            error_log('[NATIVE_EXCEPTION]: '.$e->getMessage());
+        });
+    }
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -11,6 +11,7 @@ use Native\Laravel\Commands\MigrateCommand;
 use Native\Laravel\Commands\MinifyApplicationCommand;
 use Native\Laravel\Commands\SeedDatabaseCommand;
 use Native\Laravel\Events\EventWatcher;
+use Native\Laravel\Exceptions\Handler;
 use Native\Laravel\Logging\LogWatcher;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -43,6 +44,11 @@ class NativeServiceProvider extends PackageServiceProvider
         $this->app->singleton(MigrateCommand::class, function ($app) {
             return new MigrateCommand($app['migrator'], $app['events']);
         });
+
+        $this->app->singleton(
+            \Illuminate\Contracts\Debug\ExceptionHandler::class,
+            Handler::class
+        );
 
         if (config('nativephp-internal.running')) {
             Artisan::starting(function ($artisan) {


### PR DESCRIPTION
The custom exception handler allows us to force errors to be reported out to the Electron process, which means we can display exceptions in the terminal when running `native:serve`.

This should help folks struggling with bootup errors preventing their app from showing with no clear reason why.