### PR TITLE
Passthrough $_ENV variables to artisan commands

### DIFF
--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -81,6 +81,8 @@ class ChildProcess
     {
         $cmd = ['artisan', ...(array) $cmd];
 
+        $env = array_merge($_ENV, $env ?? []);
+
         return $this->php($cmd, $alias, env: $env, persistent: $persistent);
     }
 


### PR DESCRIPTION
### The problem 

I got an artisan command that sends notifications

**NativeAppServiceProvider.php**
```php
ChildProcess::artisan(
    cmd: 'app:forge-checker',
    alias: 'forge',
    persistent: true,
);
```

**app:forge-checker** artisan command
```php
Notification::title('✅ Deployment finished')
    ->message($commit->watched_website->name . ' has been deployed')
    ->show();
```

‼️ This notification wasn't showing up because it was missing the NATIVEPHP_ env variables needed to send a request to the Electron part.

----
### Current solution
A simple fix is to pass nativephp env variables like this.

```php
ChildProcess::artisan(
    cmd: 'app:forge-checker',
    alias: 'forge',
    env: $_ENV,
    persistent: true,
);
```

----
### Proposed solution
I would like to argue that `ChildProcess::artisan()` should pass through those variables by default.

I think it's expected that everything we write in the Laravel part should just work. 
That's why I didn't pass $_ENV in `php()` or `start()` functions by default, only in `artisan()`