### PR TITLE
Fix migrations when database does not exist

### DIFF
--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -4,7 +4,6 @@ namespace Native\Laravel;
 
 use Illuminate\Console\Application;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Native\Laravel\Commands\FreshCommand;
 use Native\Laravel\Commands\LoadPHPConfigurationCommand;
@@ -112,8 +111,6 @@ class NativeServiceProvider extends PackageServiceProvider
 
             if (! file_exists($databasePath)) {
                 touch($databasePath);
-
-                Artisan::call('native:migrate');
             }
         }
 


### PR DESCRIPTION
My previous PR #408 fixed `native:migrate:fresh` but only when database already existed. 😢
When database is missing, it does not migrate at all.

It seems that the `Artisan::call` is not needed at all during the database creation since the parent handler will migrate the database anyway.

Please check if I'm right before merging. It did solve the problem for me but I wouldn't want to break something.

Sorry for the confusion.