### PR TITLE
Fix some DB stuff

### DIFF
--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -128,8 +128,10 @@ class NativeServiceProvider extends PackageServiceProvider
 
         config(['database.default' => 'nativephp']);
 
-        DB::statement('PRAGMA journal_mode=WAL;');
-        DB::statement('PRAGMA busy_timeout=5000;');
+        if (file_exists($databasePath)) {
+            DB::statement('PRAGMA journal_mode=WAL;');
+            DB::statement('PRAGMA busy_timeout=5000;');
+        }
     }
 
     public function removeDatabase()

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -57,6 +57,7 @@ class NativeServiceProvider extends PackageServiceProvider
                 $app->resolveCommands([
                     LoadStartupConfigurationCommand::class,
                     LoadPHPConfigurationCommand::class,
+                    MigrateCommand::class,
                 ]);
             });
 

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -47,12 +47,12 @@ class NativeServiceProvider extends PackageServiceProvider
             return new MigrateCommand($app['migrator'], $app['events']);
         });
 
-        $this->app->singleton(
-            \Illuminate\Contracts\Debug\ExceptionHandler::class,
-            Handler::class
-        );
-
         if (config('nativephp-internal.running')) {
+            $this->app->singleton(
+                \Illuminate\Contracts\Debug\ExceptionHandler::class,
+                Handler::class
+            );
+
             Application::starting(function ($app) {
                 $app->resolveCommands([
                     LoadStartupConfigurationCommand::class,

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -140,13 +140,11 @@ class NativeServiceProvider extends PackageServiceProvider
 
         if (config('app.debug')) {
             $databasePath = database_path('nativephp.sqlite');
-
-            if (! file_exists($databasePath)) {
-                return;
-            }
         }
 
-        unlink($databasePath);
+        @unlink($databasePath);
+        @unlink($databasePath.'-shm');
+        @unlink($database.'-wal');
     }
 
     protected function configureDisks(): void


### PR DESCRIPTION
Off the back of #408, some other issues came to light.

- `native:migrate` call doesn't work _inside_ the service provider due to the command not actually being resolved yet
- Configuring WAL mode only makes sense if we definitely have a DB to run those statements against
- When removing the database (using `native:migrate:fresh`), we should clean up the SQLite WAL-mode files
- Bonus: the exception handler is redundant and shouldn't run when we're not in a running NativePHP app context