### PR TITLE
Improvements to window test doubles

### DIFF
--- a/src/Facades/Window.php
+++ b/src/Facades/Window.php
@@ -22,7 +22,7 @@ class Window extends Facade
 {
     public static function fake()
     {
-        return tap(new WindowManagerFake, function ($fake) {
+        return tap(static::getFacadeApplication()->make(WindowManagerFake::class), function ($fake) {
             static::swap($fake);
         });
     }

--- a/src/Fakes/WindowManagerFake.php
+++ b/src/Fakes/WindowManagerFake.php
@@ -2,6 +2,7 @@
 
 namespace Native\Laravel\Fakes;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Native\Laravel\Contracts\WindowManager as WindowManagerContract;
 use Native\Laravel\Windows\Window;
@@ -71,19 +72,82 @@ class WindowManagerFake implements WindowManagerContract
         return Arr::first($matchingWindows);
     }
 
-    public function assertOpened(string $id): void
+    /**
+     * @param  string|Closure(string): bool  $id
+     */
+    public function assertOpened(string|Closure $id): void
     {
-        PHPUnit::assertContains($id, $this->opened);
+        if (is_callable($id) === false) {
+            PHPUnit::assertContains($id, $this->opened);
+
+            return;
+        }
+
+        $hit = empty(
+            array_filter(
+                $this->opened,
+                fn (string $openedId) => $id($openedId) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
     }
 
-    public function assertClosed(?string $id): void
+    /**
+     * @param  string|Closure(string): bool  $id
+     */
+    public function assertClosed(string|Closure $id): void
     {
-        PHPUnit::assertContains($id, $this->closed);
+        if (is_callable($id) === false) {
+            PHPUnit::assertContains($id, $this->closed);
+
+            return;
+        }
+
+        $hit = empty(
+            array_filter(
+                $this->closed,
+                fn (mixed $closedId) => $id($closedId) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
     }
 
-    public function assertHidden(?string $id): void
+    /**
+     * @param  string|Closure(string): bool  $id
+     */
+    public function assertHidden(string|Closure $id): void
     {
-        PHPUnit::assertContains($id, $this->hidden);
+        if (is_callable($id) === false) {
+            PHPUnit::assertContains($id, $this->hidden);
+
+            return;
+        }
+
+        $hit = empty(
+            array_filter(
+                $this->hidden,
+                fn (mixed $hiddenId) => $id($hiddenId) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
+    }
+
+    public function assertOpenedCount(int $expected): void
+    {
+        PHPUnit::assertCount($expected, $this->opened);
+    }
+
+    public function assertClosedCount(int $expected): void
+    {
+        PHPUnit::assertCount($expected, $this->closed);
+    }
+
+    public function assertHiddenCount(int $expected): void
+    {
+        PHPUnit::assertCount($expected, $this->hidden);
     }
 
     private function ensureForceReturnWindowsProvided(): void

--- a/tests/Fakes/FakeWindowManagerTest.php
+++ b/tests/Fakes/FakeWindowManagerTest.php
@@ -1,10 +1,13 @@
 <?php
 
+use Illuminate\Support\Facades\Http;
 use Native\Laravel\Contracts\WindowManager as WindowManagerContract;
 use Native\Laravel\Facades\Window;
 use Native\Laravel\Fakes\WindowManagerFake;
+use Native\Laravel\Windows\PendingOpenWindow;
 use Native\Laravel\Windows\Window as WindowClass;
 use PHPUnit\Framework\AssertionFailedError;
+use Webmozart\Assert\InvalidArgumentException;
 
 use function Pest\Laravel\swap;
 
@@ -15,8 +18,13 @@ it('swaps implementations using facade', function () {
 });
 
 it('asserts that a window was opened', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    Http::fake(['*' => Http::response(status: 200)]);
 
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    $fake->alwaysReturnWindows([
+        new PendingOpenWindow('doesnt-matter'),
+    ]);
     app(WindowManagerContract::class)->open('main');
     app(WindowManagerContract::class)->open('secondary');
 
@@ -33,7 +41,13 @@ it('asserts that a window was opened', function () {
 });
 
 it('asserts that a window was opened using callable', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    Http::fake(['*' => Http::response(status: 200)]);
+
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    $fake->alwaysReturnWindows([
+        new PendingOpenWindow('doesnt-matter'),
+    ]);
 
     app(WindowManagerContract::class)->open('main');
     app(WindowManagerContract::class)->open('secondary');
@@ -51,7 +65,7 @@ it('asserts that a window was opened using callable', function () {
 });
 
 it('asserts that a window was closed', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->close('main');
     app(WindowManagerContract::class)->close('secondary');
@@ -69,7 +83,7 @@ it('asserts that a window was closed', function () {
 });
 
 it('asserts that a window was closed using callable', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->close('main');
     app(WindowManagerContract::class)->close('secondary');
@@ -87,7 +101,7 @@ it('asserts that a window was closed using callable', function () {
 });
 
 it('asserts that a window was hidden', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->hide('main');
     app(WindowManagerContract::class)->hide('secondary');
@@ -105,7 +119,7 @@ it('asserts that a window was hidden', function () {
 });
 
 it('asserts that a window was hidden using callable', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->hide('main');
     app(WindowManagerContract::class)->hide('secondary');
@@ -123,7 +137,13 @@ it('asserts that a window was hidden using callable', function () {
 });
 
 it('asserts opened count', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    Http::fake(['*' => Http::response(status: 200)]);
+
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    $fake->alwaysReturnWindows([
+        new PendingOpenWindow('doesnt-matter'),
+    ]);
 
     app(WindowManagerContract::class)->open('main');
     app(WindowManagerContract::class)->open();
@@ -141,7 +161,7 @@ it('asserts opened count', function () {
 });
 
 it('asserts closed count', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->close('main');
     app(WindowManagerContract::class)->close();
@@ -159,7 +179,7 @@ it('asserts closed count', function () {
 });
 
 it('asserts hidden count', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->hide('main');
     app(WindowManagerContract::class)->hide();
@@ -177,7 +197,7 @@ it('asserts hidden count', function () {
 });
 
 it('forces the return value of current window', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     $fake->alwaysReturnWindows($windows = [
         new WindowClass('testA'),
@@ -188,7 +208,7 @@ it('forces the return value of current window', function () {
 });
 
 it('forces the return value of all windows', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     $fake->alwaysReturnWindows($windows = [
         new WindowClass('testA'),
@@ -199,7 +219,7 @@ it('forces the return value of all windows', function () {
 });
 
 it('forces the return value of a specific window', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     $fake->alwaysReturnWindows($windows = [
         new WindowClass('testA'),
@@ -211,7 +231,7 @@ it('forces the return value of a specific window', function () {
 });
 
 test('that the get method throws an exception if multiple matching window ids exist', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     $fake->alwaysReturnWindows($windows = [
         new WindowClass('testA'),
@@ -219,26 +239,79 @@ test('that the get method throws an exception if multiple matching window ids ex
     ]);
 
     app(WindowManagerContract::class)->get('testA');
-})->throws(AssertionFailedError::class);
+})->throws(InvalidArgumentException::class);
 
 test('that the get method throws an exception if no matching window id exists', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     $fake->alwaysReturnWindows($windows = [
         new WindowClass('testA'),
     ]);
 
     app(WindowManagerContract::class)->get('testB');
-})->throws(AssertionFailedError::class);
+})->throws(InvalidArgumentException::class);
 
 test('that the current method throws an exception if no forced window return values are provided', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->current();
-})->throws(AssertionFailedError::class);
+})->throws(InvalidArgumentException::class);
 
 test('that the all method throws an exception if no forced window return values are provided', function () {
-    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
 
     app(WindowManagerContract::class)->all();
-})->throws(AssertionFailedError::class);
+})->throws(InvalidArgumentException::class);
+
+test('that the open method throws an exception if no forced window return values are provided', function () {
+    Http::fake([
+        '*' => Http::response(status: 200),
+    ]);
+
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    app(WindowManagerContract::class)->open('test');
+})->throws(InvalidArgumentException::class);
+
+test('that the open method throws an exception if multiple matching window ids exist', function () {
+    Http::fake([
+        '*' => Http::response(status: 200),
+    ]);
+
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    $fake->alwaysReturnWindows($windows = [
+        new WindowClass('testA'),
+        new WindowClass('testA'),
+    ]);
+
+    app(WindowManagerContract::class)->open('testA');
+})->throws(InvalidArgumentException::class);
+
+test('that the open method returns a random window if none match the id provided', function () {
+    Http::fake([
+        '*' => Http::response(status: 200),
+    ]);
+
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    $fake->alwaysReturnWindows($windows = [
+        new PendingOpenWindow('testA'),
+    ]);
+
+    expect($windows)->toContain(app(WindowManagerContract::class)->open('testC'));
+});
+
+test('that the open method returns a window if a matching window id exists', function () {
+    Http::fake([
+        '*' => Http::response(status: 200),
+    ]);
+
+    swap(WindowManagerContract::class, $fake = app(WindowManagerFake::class));
+
+    $fake->alwaysReturnWindows($windows = [
+        new PendingOpenWindow('testA'),
+    ]);
+
+    expect(app(WindowManagerContract::class)->open('testA'))->toBe($windows[0]);
+});

--- a/tests/Fakes/FakeWindowManagerTest.php
+++ b/tests/Fakes/FakeWindowManagerTest.php
@@ -26,8 +26,24 @@ it('asserts that a window was opened', function () {
     try {
         $fake->assertOpened('tertiary');
     } catch (AssertionFailedError) {
-        expect(true)->toBeTrue();
+        return;
+    }
 
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts that a window was opened using callable', function () {
+    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+
+    app(WindowManagerContract::class)->open('main');
+    app(WindowManagerContract::class)->open('secondary');
+
+    $fake->assertOpened(fn (string $id) => $id === 'main');
+    $fake->assertOpened(fn (string $id) => $id === 'secondary');
+
+    try {
+        $fake->assertOpened(fn (string $id) => $id === 'tertiary');
+    } catch (AssertionFailedError) {
         return;
     }
 
@@ -46,8 +62,24 @@ it('asserts that a window was closed', function () {
     try {
         $fake->assertClosed('tertiary');
     } catch (AssertionFailedError) {
-        expect(true)->toBeTrue();
+        return;
+    }
 
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts that a window was closed using callable', function () {
+    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+
+    app(WindowManagerContract::class)->close('main');
+    app(WindowManagerContract::class)->close('secondary');
+
+    $fake->assertClosed(fn (string $id) => $id === 'main');
+    $fake->assertClosed(fn (string $id) => $id === 'secondary');
+
+    try {
+        $fake->assertClosed(fn (string $id) => $id === 'tertiary');
+    } catch (AssertionFailedError) {
         return;
     }
 
@@ -66,8 +98,78 @@ it('asserts that a window was hidden', function () {
     try {
         $fake->assertHidden('tertiary');
     } catch (AssertionFailedError) {
-        expect(true)->toBeTrue();
+        return;
+    }
 
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts that a window was hidden using callable', function () {
+    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+
+    app(WindowManagerContract::class)->hide('main');
+    app(WindowManagerContract::class)->hide('secondary');
+
+    $fake->assertHidden(fn (string $id) => $id === 'main');
+    $fake->assertHidden(fn (string $id) => $id === 'secondary');
+
+    try {
+        $fake->assertHidden(fn (string $id) => $id === 'tertiary');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts opened count', function () {
+    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+
+    app(WindowManagerContract::class)->open('main');
+    app(WindowManagerContract::class)->open();
+    app(WindowManagerContract::class)->open();
+
+    $fake->assertOpenedCount(3);
+
+    try {
+        $fake->assertOpenedCount(4);
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts closed count', function () {
+    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+
+    app(WindowManagerContract::class)->close('main');
+    app(WindowManagerContract::class)->close();
+    app(WindowManagerContract::class)->close();
+
+    $fake->assertClosedCount(3);
+
+    try {
+        $fake->assertClosedCount(4);
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts hidden count', function () {
+    swap(WindowManagerContract::class, $fake = new WindowManagerFake);
+
+    app(WindowManagerContract::class)->hide('main');
+    app(WindowManagerContract::class)->hide();
+    app(WindowManagerContract::class)->hide();
+
+    $fake->assertHiddenCount(3);
+
+    try {
+        $fake->assertHiddenCount(4);
+    } catch (AssertionFailedError) {
         return;
     }
 


### PR DESCRIPTION
Continuing some work left from #422 

@simonhamp there were some quirky HTTP client issues which I discovered once I took it for a spin in a real test suite for an app I'm working on. Fixed most of them, but we still need an HTTP fake to make it play nice. I was torn as to whether the test double should do the HTTP faking, or leave it up to the user. I opted for the latter. This can be documented. 

Here's a general happy-path test snippet, if you'd like to update the docs with a testing section at some point:

```php
 #[\PHPUnit\Framework\Attributes\Test]
public function it_opens_a_new_nativephp_ping_window(): void
{
    // Arrange
    Http::fake(); // Native PHP API URL should be provided to avoid faking everything else
    Window::fake();
    Window::alwaysReturnWindows([
        $mockWindow = Mockery::mock(WindowImplementation::class)->makePartial(),
    ]);

    $mockWindow->shouldReceive('route')->once()->with('ping')->andReturnSelf();
    $mockWindow->shouldReceive('showDevTools')->once()->with(false)->andReturnSelf();
    $mockWindow->shouldReceive('titleBarHiddenInset')->once()->andReturnSelf();
    $mockWindow->shouldReceive('transparent')->once()->andReturnSelf();
    $mockWindow->shouldReceive('height')->once()->with(500)->andReturnSelf();
    $mockWindow->shouldReceive('width')->once()->with(775)->andReturnSelf();
    $mockWindow->shouldReceive('minHeight')->once()->with(500)->andReturnSelf();
    $mockWindow->shouldReceive('minWidth')->once()->with(775)->andReturnSelf();

    // Act
    Livewire::test(Search::class)->call('openPing');

    // Assert
    Window::assertOpened(fn (string $windowId) => Str::startsWith($windowId, ['ping']));
}
```

The mocks are a little disgusting, so perhaps a test double for the window implementation – not just the manager – would be helpful in the future. I'll release more of these as I come across the use case.