### PR TITLE
fix: Notification facade docbloc

### DIFF
--- a/src/Facades/Notification.php
+++ b/src/Facades/Notification.php
@@ -5,9 +5,9 @@ namespace Native\Laravel\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static object title(string $title)
- * @method static object event(string $event)
- * @method static object message(string $body)
+ * @method static static title(string $title)
+ * @method static static event(string $event)
+ * @method static static message(string $body)
  * @method static void show()
  */
 class Notification extends Facade


### PR DESCRIPTION
Method returns `static` instead of `object`