### PR TITLE
fix: child process cmd: option except iterable array

### DIFF
--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -58,7 +58,7 @@ class ChildProcess
         ?array $env = null,
         bool $persistent = false
     ): static {
-        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
+        $cmd = $this->ensureCmdIsAnIndexedArray($cmd);
 
         $process = $this->client->post('child-process/start', [
             'alias' => $alias,
@@ -73,8 +73,8 @@ class ChildProcess
 
     public function php(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
-        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
-        
+        $cmd = $this->ensureCmdIsAnIndexedArray($cmd);
+
         $process = $this->client->post('child-process/start-php', [
             'alias' => $alias,
             'cmd' => $cmd,
@@ -134,5 +134,16 @@ class ChildProcess
         }
 
         return $this;
+    }
+
+    protected function ensureCmdIsAnIndexedArray(string|array $cmd): array
+    {
+        if (is_string($cmd)) {
+            return [$cmd];
+        }
+
+        if (array_keys($cmd) !== range(0, count($cmd) - 1)) {
+            throw new \InvalidArgumentException('Only indexed arrays are supported for the cmd: argument.');
+        }
     }
 }

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -51,6 +51,10 @@ class ChildProcess
         return $hydrated;
     }
 
+    /**
+     * @param  string|string[]  $cmd
+     * @return $this
+     */
     public function start(
         string|array $cmd,
         string $alias,
@@ -58,7 +62,7 @@ class ChildProcess
         ?array $env = null,
         bool $persistent = false
     ): static {
-        $cmd = $this->ensureCmdIsAnIndexedArray($cmd);
+        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
 
         $process = $this->client->post('child-process/start', [
             'alias' => $alias,
@@ -71,9 +75,13 @@ class ChildProcess
         return $this->fromRuntimeProcess($process);
     }
 
+    /**
+     * @param  string|string[]  $cmd
+     * @return $this
+     */
     public function php(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
-        $cmd = $this->ensureCmdIsAnIndexedArray($cmd);
+        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
 
         $process = $this->client->post('child-process/start-php', [
             'alias' => $alias,
@@ -86,9 +94,15 @@ class ChildProcess
         return $this->fromRuntimeProcess($process);
     }
 
+    /**
+     * @param  string|string[]  $cmd
+     * @return $this
+     */
     public function artisan(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
-        $cmd = ['artisan', ...(array) $cmd];
+        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
+
+        $cmd = ['artisan', ...$cmd];
 
         return $this->php($cmd, $alias, env: $env, persistent: $persistent);
     }
@@ -134,16 +148,5 @@ class ChildProcess
         }
 
         return $this;
-    }
-
-    protected function ensureCmdIsAnIndexedArray(string|array $cmd): array
-    {
-        if (is_string($cmd)) {
-            return [$cmd];
-        }
-
-        if (array_keys($cmd) !== range(0, count($cmd) - 1)) {
-            throw new \InvalidArgumentException('Only indexed arrays are supported for the cmd: argument.');
-        }
     }
 }

--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -58,10 +58,11 @@ class ChildProcess
         ?array $env = null,
         bool $persistent = false
     ): static {
+        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
 
         $process = $this->client->post('child-process/start', [
             'alias' => $alias,
-            'cmd' => (array) $cmd,
+            'cmd' => $cmd,
             'cwd' => $cwd ?? base_path(),
             'env' => $env,
             'persistent' => $persistent,
@@ -72,9 +73,11 @@ class ChildProcess
 
     public function php(string|array $cmd, string $alias, ?array $env = null, ?bool $persistent = false): self
     {
+        $cmd = is_array($cmd) ? array_values($cmd) : [$cmd];
+        
         $process = $this->client->post('child-process/start-php', [
             'alias' => $alias,
-            'cmd' => (array) $cmd,
+            'cmd' => $cmd,
             'cwd' => $cwd ?? base_path(),
             'env' => $env,
             'persistent' => $persistent,


### PR DESCRIPTION
I encountered an error that was not understandable at first glance.
TypeScript was complaining that cmd: was not iterable.

This error was crashing the app before even showing a window.

For context, I was writing this  
```php
ChildProcess::artisan(cmd: ['app:victron-mqtt','--vrmid' => 'myvrmid'], alias: 'something');
```

instead of  
```php
ChildProcess::artisan(cmd: ['app:victron-mqtt','--vrmid=myvrmid'], alias: 'something');
```

Did you notice the difference?

-----
Screenshot of the error:  
<img width="1074" alt="Capture d’écran 2024-11-21 à 23 49 58" src="https://github.com/user-attachments/assets/7210c2ac-d64e-4f20-bf05-b6c07b190fe9">
