### PR TITLE
Global shortcut test double

### DIFF
--- a/src/Contracts/GlobalShortcut.php
+++ b/src/Contracts/GlobalShortcut.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Native\Laravel\Contracts;
+
+interface GlobalShortcut
+{
+    public function key(string $key): self;
+
+    public function event(string $event): self;
+
+    public function register(): void;
+
+    public function unregister(): void;
+}

--- a/src/Facades/GlobalShortcut.php
+++ b/src/Facades/GlobalShortcut.php
@@ -3,6 +3,8 @@
 namespace Native\Laravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
+use Native\Laravel\Fakes\GlobalShortcutFake;
 
 /**
  * @method static \Native\Laravel\GlobalShortcut key(string $key)
@@ -12,8 +14,15 @@ use Illuminate\Support\Facades\Facade;
  */
 class GlobalShortcut extends Facade
 {
+    public static function fake()
+    {
+        return tap(static::getFacadeApplication()->make(GlobalShortcutFake::class), function ($fake) {
+            static::swap($fake);
+        });
+    }
+
     protected static function getFacadeAccessor()
     {
-        return \Native\Laravel\GlobalShortcut::class;
+        return GlobalShortcutContract::class;
     }
 }

--- a/src/Fakes/GlobalShortcutFake.php
+++ b/src/Fakes/GlobalShortcutFake.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Native\Laravel\Fakes;
+
+use Closure;
+use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class GlobalShortcutFake implements GlobalShortcutContract
+{
+    /**
+     * @var array<int, string>
+     */
+    public array $keys = [];
+
+    /**
+     * @var array<int, string>
+     */
+    public array $events = [];
+
+    public int $registeredCount = 0;
+
+    public int $unregisteredCount = 0;
+
+    public function key(string $key): self
+    {
+        $this->keys[] = $key;
+
+        return $this;
+    }
+
+    public function event(string $event): self
+    {
+        $this->events[] = $event;
+
+        return $this;
+    }
+
+    public function register(): void
+    {
+        $this->registeredCount++;
+    }
+
+    public function unregister(): void
+    {
+        $this->unregisteredCount++;
+    }
+
+    /**
+     * @param  string|Closure(string): bool  $key
+     */
+    public function assertKey(string|Closure $key): void
+    {
+        if (is_callable($key) === false) {
+            PHPUnit::assertContains($key, $this->keys);
+
+            return;
+        }
+
+        $hit = empty(
+            array_filter(
+                $this->keys,
+                fn (string $keyIteration) => $key($keyIteration) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
+    }
+
+    /**
+     * @param  string|Closure(string): bool  $event
+     */
+    public function assertEvent(string|Closure $event): void
+    {
+        if (is_callable($event) === false) {
+            PHPUnit::assertContains($event, $this->events);
+
+            return;
+        }
+
+        $hit = empty(
+            array_filter(
+                $this->events,
+                fn (string $eventIteration) => $event($eventIteration) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
+    }
+
+    public function assertRegisteredCount(int $count): void
+    {
+        PHPUnit::assertSame($count, $this->registeredCount);
+    }
+
+    public function assertUnregisteredCount(int $count): void
+    {
+        PHPUnit::assertSame($count, $this->unregisteredCount);
+    }
+}

--- a/src/GlobalShortcut.php
+++ b/src/GlobalShortcut.php
@@ -3,8 +3,9 @@
 namespace Native\Laravel;
 
 use Native\Laravel\Client\Client;
+use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
 
-class GlobalShortcut
+class GlobalShortcut implements GlobalShortcutContract
 {
     protected string $key;
 

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -15,9 +15,11 @@ use Native\Laravel\Commands\MigrateCommand;
 use Native\Laravel\Commands\MinifyApplicationCommand;
 use Native\Laravel\Commands\SeedDatabaseCommand;
 use Native\Laravel\Contracts\ChildProcess as ChildProcessContract;
+use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
 use Native\Laravel\Contracts\WindowManager as WindowManagerContract;
 use Native\Laravel\Events\EventWatcher;
 use Native\Laravel\Exceptions\Handler;
+use Native\Laravel\GlobalShortcut as GlobalShortcutImplementation;
 use Native\Laravel\Logging\LogWatcher;
 use Native\Laravel\Windows\WindowManager as WindowManagerImplementation;
 use Spatie\LaravelPackageTools\Package;
@@ -58,6 +60,10 @@ class NativeServiceProvider extends PackageServiceProvider
 
         $this->app->bind(ChildProcessContract::class, function (Foundation $app) {
             return $app->make(ChildProcessImplementation::class);
+        });
+
+        $this->app->bind(GlobalShortcutContract::class, function (Foundation $app) {
+            return $app->make(GlobalShortcutImplementation::class);
         });
 
         if (config('nativephp-internal.running')) {

--- a/tests/Fakes/FakeGlobalShortcutTest.php
+++ b/tests/Fakes/FakeGlobalShortcutTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Native\Laravel\Facades\GlobalShortcut;
+use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
+use Native\Laravel\Fakes\GlobalShortcutFake;
+
+use PHPUnit\Framework\AssertionFailedError;
+
+use function Pest\Laravel\swap;
+
+it('swaps implementations using facade', function () {
+    GlobalShortcut::fake();
+
+    expect(app(GlobalShortcutContract::class))->toBeInstanceOf(GlobalShortcutFake::class);
+});
+
+it('asserts key using string', function () {
+    swap(GlobalShortcutContract::class, $fake = app(GlobalShortcutFake::class));
+
+    $fake->key('testA');
+    $fake->key('testB');
+
+    $fake->assertKey('testA');
+    $fake->assertKey('testB');
+
+    try {
+        $fake->assertKey('testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts key using callable', function () {
+    swap(GlobalShortcutContract::class, $fake = app(GlobalShortcutFake::class));
+
+    $fake->key('testA');
+    $fake->key('testB');
+
+    $fake->assertKey(fn (string $key) => $key === 'testA');
+    $fake->assertKey(fn (string $key) => $key === 'testB');
+
+    try {
+        $fake->assertKey(fn (string $key) => $key === 'testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts event using string', function () {
+    swap(GlobalShortcutContract::class, $fake = app(GlobalShortcutFake::class));
+
+    $fake->event('testA');
+    $fake->event('testB');
+
+    $fake->assertEvent('testA');
+    $fake->assertEvent('testB');
+
+    try {
+        $fake->assertEvent('testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts event using callable', function () {
+    swap(GlobalShortcutContract::class, $fake = app(GlobalShortcutFake::class));
+
+    $fake->event('testA');
+    $fake->event('testB');
+
+    $fake->assertEvent(fn (string $event) => $event === 'testA');
+    $fake->assertEvent(fn (string $event) => $event === 'testB');
+
+    try {
+        $fake->assertEvent(fn (string $event) => $event === 'testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts registered count', function () {
+    swap(GlobalShortcutContract::class, $fake = app(GlobalShortcutFake::class));
+
+    $fake->register();
+    $fake->register();
+    $fake->register();
+
+    $fake->assertRegisteredCount(3);
+
+    try {
+        $fake->assertRegisteredCount(2);
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts unregistered count', function () {
+    swap(GlobalShortcutContract::class, $fake = app(GlobalShortcutFake::class));
+
+    $fake->unregister();
+    $fake->unregister();
+    $fake->unregister();
+
+    $fake->assertUnregisteredCount(3);
+
+    try {
+        $fake->assertUnregisteredCount(2);
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+


### PR DESCRIPTION
- `GlobalShortcut::class` now implements `Contracts\GlobalShortcut::class` interface
- `Facades\GlobalShortcut::fake()` swaps implementations with a test double concrete
- Implement new binding in `NativeServiceProvider::class`
- Implement `GlobalShortcutFake::class` with assertion helpers
- Test that `GlobalShortcutFake::class` assertions work

This one is dead simple:

```php
final class OnWindowFocusedTest extends TestCase
{
    #[\PHPUnit\Framework\Attributes\Test]
    public function it_registers_a_hotkey_for_the_preferences_page(): void
    {
        // Arrange
        GlobalShortcut::fake();

        // Act
        $this->app->make(Dispatcher::class)->dispatch(new WindowFocused('doesnt-matter'));

        // Assert
        GlobalShortcut::assertKey('CmdOrCtrl+,');
        GlobalShortcut::assertRegisteredCount(1);
        GlobalShortcut::assertEvent(OpenPreferencesEvent::class);
    }
}
```