### PR TITLE
fix: database migration on first launch

### DIFF
--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -84,6 +84,13 @@ class NativeServiceProvider extends PackageServiceProvider
         }
     }
 
+    public function bootingPackage()
+    {
+        if (config('nativephp-internal.running')) {
+            $this->rewriteDatabase();
+        }
+    }
+
     protected function configureApp()
     {
         if (config('app.debug')) {
@@ -93,8 +100,6 @@ class NativeServiceProvider extends PackageServiceProvider
         app(EventWatcher::class)->register();
 
         $this->rewriteStoragePath();
-
-        $this->rewriteDatabase();
 
         $this->configureDisks();
 


### PR DESCRIPTION
Fixes https://github.com/NativePHP/nativephp.com/pull/65

This pull request defer the execution of `rewriteDatabase` from `register` to the `boot` method of the service provider.

Previously, we encountered an error at launch that silently failed for all subsequent executions. Even though the execution of `Artisan::call('native:migrate')` failed, the `nativephp.sqlite` file was still created.

Database was created but not migrated because the `Migrator` class was not resolved in the `register` phase of service providers. 

<img width="1081" alt="Capture d’écran 2024-12-04 à 11 42 08" src="https://github.com/user-attachments/assets/d0b33bcf-2a55-4a17-a743-988e6e7ee8d6">


