### PR TITLE
Child process queue workers

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -114,4 +114,12 @@ return [
             ],
         ],
     ],
+
+    'queue_workers' => [
+        'default' => [
+            'queues' => ['default'],
+            'memory_limit' => 128,
+            'timeout' => 60,
+        ],
+    ],
 ];

--- a/src/Contracts/QueueWorker.php
+++ b/src/Contracts/QueueWorker.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Native\Laravel\Contracts;
+
+use Native\Laravel\DTOs\QueueConfig;
+
+interface QueueWorker
+{
+    public function up(QueueConfig $config): void;
+
+    public function down(string $alias): void;
+}

--- a/src/DTOs/QueueConfig.php
+++ b/src/DTOs/QueueConfig.php
@@ -21,10 +21,6 @@ class QueueConfig
     {
         return array_map(
             function (array|string $worker, string $alias) {
-                if (is_string($worker)) {
-                    return new self($worker, ['default'], 128, 60);
-                }
-
                 return new self(
                     $alias,
                     $worker['queues'] ?? ['default'],

--- a/src/DTOs/QueueConfig.php
+++ b/src/DTOs/QueueConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Native\Laravel\DTOs;
+
+class QueueConfig
+{
+    /**
+     * @param  array<int, string>  $queuesToConsume
+     */
+    public function __construct(
+        public readonly string $alias,
+        public readonly array $queuesToConsume,
+        public readonly int $memoryLimit,
+        public readonly int $timeout,
+    ) {}
+
+    /**
+     * @return array<int, self>
+     */
+    public static function fromConfigArray(array $config): array
+    {
+        return array_map(
+            function (array|string $worker, string $alias) {
+                if (is_string($worker)) {
+                    return new self($worker, ['default'], 128, 60);
+                }
+
+                return new self(
+                    $alias,
+                    $worker['queues'] ?? ['default'],
+                    $worker['memory_limit'] ?? 128,
+                    $worker['timeout'] ?? 60,
+                );
+            },
+            $config,
+            array_keys($config),
+        );
+    }
+}

--- a/src/Events/ChildProcess/ErrorReceived.php
+++ b/src/Events/ChildProcess/ErrorReceived.php
@@ -3,11 +3,11 @@
 namespace Native\Laravel\Events\ChildProcess;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ErrorReceived implements ShouldBroadcast
+class ErrorReceived implements ShouldBroadcastNow
 {
     use Dispatchable, SerializesModels;
 

--- a/src/Events/ChildProcess/MessageReceived.php
+++ b/src/Events/ChildProcess/MessageReceived.php
@@ -3,11 +3,11 @@
 namespace Native\Laravel\Events\ChildProcess;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class MessageReceived implements ShouldBroadcast
+class MessageReceived implements ShouldBroadcastNow
 {
     use Dispatchable, SerializesModels;
 

--- a/src/Events/ChildProcess/ProcessExited.php
+++ b/src/Events/ChildProcess/ProcessExited.php
@@ -3,11 +3,11 @@
 namespace Native\Laravel\Events\ChildProcess;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ProcessExited implements ShouldBroadcast
+class ProcessExited implements ShouldBroadcastNow
 {
     use Dispatchable, SerializesModels;
 

--- a/src/Events/ChildProcess/ProcessSpawned.php
+++ b/src/Events/ChildProcess/ProcessSpawned.php
@@ -3,11 +3,11 @@
 namespace Native\Laravel\Events\ChildProcess;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ProcessSpawned implements ShouldBroadcast
+class ProcessSpawned implements ShouldBroadcastNow
 {
     use Dispatchable, SerializesModels;
 

--- a/src/Facades/QueueWorker.php
+++ b/src/Facades/QueueWorker.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Native\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Native\Laravel\Contracts\QueueWorker as QueueWorkerContract;
+use Native\Laravel\DTOs\QueueConfig;
+use Native\Laravel\Fakes\QueueWorkerFake;
+
+/**
+ * @method static void up(QueueConfig $config)
+ * @method static void down(string $alias)
+ */
+class QueueWorker extends Facade
+{
+    public static function fake()
+    {
+        return tap(static::getFacadeApplication()->make(QueueWorkerFake::class), function ($fake) {
+            static::swap($fake);
+        });
+    }
+
+    protected static function getFacadeAccessor(): string
+    {
+        self::clearResolvedInstance(QueueWorkerContract::class);
+
+        return QueueWorkerContract::class;
+    }
+}

--- a/src/Fakes/QueueWorkerFake.php
+++ b/src/Fakes/QueueWorkerFake.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Native\Laravel\Fakes;
+
+use Closure;
+use Native\Laravel\Contracts\QueueWorker as QueueWorkerContract;
+use Native\Laravel\DTOs\QueueConfig;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+class QueueWorkerFake implements QueueWorkerContract
+{
+    /**
+     * @var array<int, QueueConfig>
+     */
+    public array $ups = [];
+
+    /**
+     * @var array<int, string>
+     */
+    public array $downs = [];
+
+    public function up(QueueConfig $config): void
+    {
+        $this->ups[] = $config;
+    }
+
+    public function down(string $alias): void
+    {
+        $this->downs[] = $alias;
+    }
+
+    public function assertUp(Closure $callback): void
+    {
+        $hit = empty(
+            array_filter(
+                $this->ups,
+                fn (QueueConfig $up) => $callback($up) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
+    }
+
+    public function assertDown(string|Closure $alias): void
+    {
+        if (is_callable($alias) === false) {
+            PHPUnit::assertContains($alias, $this->downs);
+
+            return;
+        }
+
+        $hit = empty(
+            array_filter(
+                $this->downs,
+                fn (string $down) => $alias($down) === true
+            )
+        ) === false;
+
+        PHPUnit::assertTrue($hit);
+    }
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -17,7 +17,9 @@ use Native\Laravel\Commands\SeedDatabaseCommand;
 use Native\Laravel\Contracts\ChildProcess as ChildProcessContract;
 use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
 use Native\Laravel\Contracts\PowerMonitor as PowerMonitorContract;
+use Native\Laravel\Contracts\QueueWorker as QueueWorkerContract;
 use Native\Laravel\Contracts\WindowManager as WindowManagerContract;
+use Native\Laravel\DTOs\QueueConfig;
 use Native\Laravel\Events\EventWatcher;
 use Native\Laravel\Exceptions\Handler;
 use Native\Laravel\GlobalShortcut as GlobalShortcutImplementation;
@@ -73,6 +75,10 @@ class NativeServiceProvider extends PackageServiceProvider
             return $app->make(PowerMonitorImplementation::class);
         });
 
+        $this->app->bind(QueueWorkerContract::class, function (Foundation $app) {
+            return $app->make(QueueWorker::class);
+        });
+
         if (config('nativephp-internal.running')) {
             $this->app->singleton(
                 \Illuminate\Contracts\Debug\ExceptionHandler::class,
@@ -112,6 +118,8 @@ class NativeServiceProvider extends PackageServiceProvider
 
         config(['session.driver' => 'file']);
         config(['queue.default' => 'database']);
+
+        $this->fireUpQueueWorkers();
     }
 
     protected function rewriteStoragePath()
@@ -208,6 +216,15 @@ class NativeServiceProvider extends PackageServiceProvider
                     'links' => 'skip',
                 ],
             ]);
+        }
+    }
+
+    protected function fireUpQueueWorkers(): void
+    {
+        $queueConfigs = QueueConfig::fromConfigArray(config('nativephp.queue_workers'));
+
+        foreach ($queueConfigs as $queueConfig) {
+            $this->app->make(QueueWorkerContract::class)->up($queueConfig);
         }
     }
 }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -119,7 +119,10 @@ class NativeServiceProvider extends PackageServiceProvider
         config(['session.driver' => 'file']);
         config(['queue.default' => 'database']);
 
-        $this->fireUpQueueWorkers();
+        // XXX: This logic may need to change when we ditch the internal web server
+        if (! $this->app->runningInConsole()) {
+            $this->fireUpQueueWorkers();
+        }
     }
 
     protected function rewriteStoragePath()

--- a/src/QueueWorker.php
+++ b/src/QueueWorker.php
@@ -12,8 +12,18 @@ class QueueWorker implements QueueWorkerContract
         private readonly ChildProcessContract $childProcess,
     ) {}
 
-    public function up(QueueConfig $config): void
+    public function up(string|QueueConfig $config): void
     {
+        if (is_string($config) && config()->has("nativephp.queue_workers.{$config}")) {
+            $config = QueueConfig::fromConfigArray([
+                $config => config("nativephp.queue_workers.{$config}")
+            ])[0];
+        }
+
+        if (! $config instanceof QueueConfig) {
+            throw new \InvalidArgumentException("Invalid queue configuration alias [$config]");
+        }
+
         $this->childProcess->php(
             [
                 '-d',

--- a/src/QueueWorker.php
+++ b/src/QueueWorker.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Native\Laravel;
+
+use Native\Laravel\Contracts\ChildProcess as ChildProcessContract;
+use Native\Laravel\Contracts\QueueWorker as QueueWorkerContract;
+use Native\Laravel\DTOs\QueueConfig;
+
+class QueueWorker implements QueueWorkerContract
+{
+    public function __construct(
+        private readonly ChildProcessContract $childProcess,
+    ) {}
+
+    public function up(QueueConfig $config): void
+    {
+        $this->childProcess->php(
+            [
+                '-d',
+                "memory_limit={$config->memoryLimit}M",
+                'artisan',
+                'queue:work',
+                "--name={$config->alias}",
+                '--queue='.implode(',', $config->queuesToConsume),
+                "--memory={$config->memoryLimit}",
+                "--timeout={$config->timeout}",
+            ],
+            $config->alias,
+            persistent: true,
+        );
+    }
+
+    public function down(string $alias): void
+    {
+        $this->childProcess->stop($alias);
+    }
+}

--- a/src/QueueWorker.php
+++ b/src/QueueWorker.php
@@ -16,7 +16,7 @@ class QueueWorker implements QueueWorkerContract
     {
         if (is_string($config) && config()->has("nativephp.queue_workers.{$config}")) {
             $config = QueueConfig::fromConfigArray([
-                $config => config("nativephp.queue_workers.{$config}")
+                $config => config("nativephp.queue_workers.{$config}"),
             ])[0];
         }
 

--- a/tests/DTOs/QueueWorkerTest.php
+++ b/tests/DTOs/QueueWorkerTest.php
@@ -44,8 +44,8 @@ test('the factory method generates an array of config objects for several format
     ],
     [
         'queue_workers' => [
-            'some_worker',
-            'another_worker',
+            'some_worker' => [],
+            'another_worker' => [],
         ],
     ],
     [

--- a/tests/DTOs/QueueWorkerTest.php
+++ b/tests/DTOs/QueueWorkerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Support\Arr;
+use Native\Laravel\DTOs\QueueConfig;
+
+test('the factory method generates an array of config objects for several formats', function (array $config) {
+    $configObject = QueueConfig::fromConfigArray($config);
+
+    expect($configObject)->toBeArray();
+    expect($configObject)->toHaveCount(count($config));
+
+    foreach ($config as $alias => $worker) {
+        if (is_string($worker)) {
+            expect(
+                Arr::first(
+                    array_filter($configObject, fn (QueueConfig $config) => $config->alias === $worker))
+            )->queuesToConsume->toBe(['default']
+            );
+
+            expect(Arr::first(array_filter($configObject, fn (QueueConfig $config) => $config->alias === $worker)))->memoryLimit->toBe(128);
+            expect(Arr::first(array_filter($configObject, fn (QueueConfig $config) => $config->alias === $worker)))->timeout->toBe(60);
+
+            continue;
+        }
+
+        expect(
+            Arr::first(
+                array_filter($configObject, fn (QueueConfig $config) => $config->alias === $alias))
+        )->queuesToConsume->toBe($worker['queues'] ?? ['default']
+        );
+
+        expect(Arr::first(array_filter($configObject, fn (QueueConfig $config) => $config->alias === $alias)))->memoryLimit->toBe($worker['memory_limit'] ?? 128);
+        expect(Arr::first(array_filter($configObject, fn (QueueConfig $config) => $config->alias === $alias)))->timeout->toBe($worker['timeout'] ?? 60);
+    }
+})->with([
+    [
+        'queue_workers' => [
+            'some_worker' => [
+                'queues' => ['default'],
+                'memory_limit' => 64,
+                'timeout' => 60,
+            ],
+        ],
+    ],
+    [
+        'queue_workers' => [
+            'some_worker',
+            'another_worker',
+        ],
+    ],
+    [
+        'queue_workers' => [
+            'some_worker' => [
+            ],
+            'another_worker' => [
+                'queues' => ['default', 'another'],
+            ],
+            'yet_another_worker' => [
+                'memory_limit' => 256,
+            ],
+            'one_more_worker' => [
+                'timeout' => 120,
+            ],
+        ],
+    ],
+]);

--- a/tests/Fakes/FakeQueueWorkerTest.php
+++ b/tests/Fakes/FakeQueueWorkerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Native\Laravel\Contracts\QueueWorker as QueueWorkerContract;
+use Native\Laravel\DTOs\QueueConfig;
+use Native\Laravel\Facades\QueueWorker;
+use Native\Laravel\Fakes\QueueWorkerFake;
+use PHPUnit\Framework\AssertionFailedError;
+
+use function Pest\Laravel\swap;
+
+it('swaps implementations using facade', function () {
+    QueueWorker::fake();
+
+    expect(app(QueueWorkerContract::class))->toBeInstanceOf(QueueWorkerFake::class);
+});
+
+it('asserts up using callable', function () {
+    swap(QueueWorkerContract::class, $fake = app(QueueWorkerFake::class));
+
+    $fake->up(new QueueConfig('testA', ['default'], 123, 123));
+    $fake->up(new QueueConfig('testB', ['default'], 123, 123));
+
+    $fake->assertUp(fn (QueueConfig $up) => $up->alias === 'testA');
+    $fake->assertUp(fn (QueueConfig $up) => $up->alias === 'testB');
+
+    try {
+        $fake->assertUp(fn (QueueConfig $up) => $up->alias === 'testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts down using string', function () {
+    swap(QueueWorkerContract::class, $fake = app(QueueWorkerFake::class));
+
+    $fake->down('testA');
+    $fake->down('testB');
+
+    $fake->assertDown('testA');
+    $fake->assertDown('testB');
+
+    try {
+        $fake->assertDown('testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});
+
+it('asserts down using callable', function () {
+    swap(QueueWorkerContract::class, $fake = app(QueueWorkerFake::class));
+
+    $fake->down('testA');
+    $fake->down('testB');
+
+    $fake->assertDown(fn (string $alias) => $alias === 'testA');
+    $fake->assertDown(fn (string $alias) => $alias === 'testB');
+
+    try {
+        $fake->assertDown(fn (string $alias) => $alias === 'testC');
+    } catch (AssertionFailedError) {
+        return;
+    }
+
+    $this->fail('Expected assertion to fail');
+});

--- a/tests/QueueWorker/QueueWorkerTest.php
+++ b/tests/QueueWorker/QueueWorkerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Native\Laravel\DTOs\QueueConfig;
+use Native\Laravel\Facades\ChildProcess;
+use Native\Laravel\Facades\QueueWorker;
+
+it('hits the child process with relevant queue config to spin up a new queue worker', function () {
+    ChildProcess::fake();
+    $config = new QueueConfig('some_worker', ['default'], 128, 61);
+
+    QueueWorker::up($config);
+
+    ChildProcess::assertPhp(function (array $cmd, string $alias, $env, $persistent) {
+        expect($cmd)->toBe([
+            '-d',
+            'memory_limit=128M',
+            'artisan',
+            'queue:work',
+            "--name={$alias}",
+            '--queue=default',
+            '--memory=128',
+            '--timeout=61',
+        ]);
+
+        expect($alias)->toBe('some_worker');
+        expect($env)->toBeNull();
+        expect($persistent)->toBeTrue();
+
+        return true;
+    });
+});
+
+it('hits the child process with relevant alias spin down a queue worker', function () {
+    ChildProcess::fake();
+
+    QueueWorker::down('some_worker');
+
+    ChildProcess::assertStop('some_worker');
+});


### PR DESCRIPTION
Commits related to feature discussed in #443

> [!NOTE]  
> `nativephp/electron` must be updated to remove javascript-side queue system


- Remove `ShouldBroadcast` in favor of `ShouldBroadcastNow` in `Events\\ChildProcess` namespace
- Implement `QueueWorker::class`
- Add new binding to `NativeServiceProvider::class`
- Fire up workers: iterate through queue worker config in `NativeServiceProvider::configureApp()`

- Test `QueueWorker::up()`, `QueueWorker::down()`
- Test `QueueWorkerFake::class` assertions work as expected