### PR TITLE
feat: default notification title

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -12,7 +12,9 @@ class Notification
 
     protected string $event = '';
 
-    final public function __construct(protected Client $client) {}
+    final public function __construct(protected Client $client) {
+        $this->title = config('app.name');
+    }
 
     public static function new()
     {


### PR DESCRIPTION
This allows for one line notification without defining a title.

```php
Notification::message('Reboot in progress..')->show();
```