### PR TITLE
Fix menubar not ready

### DIFF
--- a/src/Events/MenuBar/MenuBarCreated.php
+++ b/src/Events/MenuBar/MenuBarCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Native\Laravel\Events\MenuBar;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MenuBarCreated implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/MenuBar/PendingCreateMenuBar.php
+++ b/src/MenuBar/PendingCreateMenuBar.php
@@ -9,11 +9,11 @@ class PendingCreateMenuBar extends MenuBar
     public function __destruct()
     {
         if (! $this->created) {
-            $this->now();
+            $this->create();
         }
     }
 
-    public function now(): void
+    public function create(): void
     {
         $this->client->post('menu-bar/create', $this->toArray());
         $this->created = true;

--- a/src/MenuBar/PendingCreateMenuBar.php
+++ b/src/MenuBar/PendingCreateMenuBar.php
@@ -9,11 +9,11 @@ class PendingCreateMenuBar extends MenuBar
     public function __destruct()
     {
         if (! $this->created) {
-            $this->create();
+            $this->now();
         }
     }
 
-    public function create(): void
+    public function now(): void
     {
         $this->client->post('menu-bar/create', $this->toArray());
         $this->created = true;

--- a/src/MenuBar/PendingCreateMenuBar.php
+++ b/src/MenuBar/PendingCreateMenuBar.php
@@ -4,18 +4,13 @@ namespace Native\Laravel\MenuBar;
 
 class PendingCreateMenuBar extends MenuBar
 {
-    protected bool $created = false;
-
     public function __destruct()
     {
-        if (! $this->created) {
-            $this->create();
-        }
+        $this->create();
     }
 
-    public function create(): void
+    protected function create(): void
     {
         $this->client->post('menu-bar/create', $this->toArray());
-        $this->created = true;
     }
 }

--- a/src/MenuBar/PendingCreateMenuBar.php
+++ b/src/MenuBar/PendingCreateMenuBar.php
@@ -4,13 +4,18 @@ namespace Native\Laravel\MenuBar;
 
 class PendingCreateMenuBar extends MenuBar
 {
+    protected bool $created = false;
+
     public function __destruct()
     {
-        $this->create();
+        if (! $this->created) {
+            $this->create();
+        }
     }
 
-    protected function create(): void
+    public function create(): void
     {
         $this->client->post('menu-bar/create', $this->toArray());
+        $this->created = true;
     }
 }


### PR DESCRIPTION
The creation of MenuBar is actually asynchronous, which is not practical in PHP since we cannot use await if necessary.

This gives the ability to call `create` ourselves instead of `__destruct`.

Fix the following situation in the service provider:
```php
MenuBar::create()
    ->route('dashboard');

// Start the background task that updates the menu bar label every second
ChildProcess::artisan(
    cmd: 'app:background-task',
    alias: 'background-task',
    persistent: true,
);

// A temporary menubar is created before the real one 
// and the menubar label flickers once because create() is called after
```

With this PR, we can't take control and wait for the menubar to be ready by:
```php 
MenuBar::create()
    ->route('dashboard')
    ->now();
```

The repetition of `create` is not ideal. We can change the name of the latter without it being a breaking change.

Goes with: https://github.com/NativePHP/electron/pull/150