### PR TITLE
Fix: Return type mismatch between screen facade and screen class methods.

### DIFF
--- a/src/Screen.php
+++ b/src/Screen.php
@@ -18,12 +18,12 @@ class Screen
         return $this->client->get('screen/displays')->json('displays');
     }
 
-    public function primary(): object
+    public function primary(): array
     {
         return $this->client->get('screen/primary-display')->json('primaryDisplay');
     }
 
-    public function active(): object
+    public function active(): array
     {
         return $this->client->get('screen/active')->json();
     }


### PR DESCRIPTION
This pull request fixes method return type mismatches between the `Native\Laravel\Facades\Screen` facade and `Native\Laravel\Screen` class. 

Before, when a method was called using the facade that had a return type mismatch, it would cause a TypeError, refer to screenshot below.

![NativePHP-TypeError-Screenshot](https://github.com/user-attachments/assets/1bbe17b1-5e4d-47d3-bb6d-f19ab7756922)

This fix changed the return types on methods in the `Native\Laravel\Screen` class to match their corresponding method signature in the `Native\Laravel\Facades\Screen` facade as this did not introduce new issues in current code that is using the methods in question which are listed below.

- `Native\Laravel\Screen::primary()`
- `Native\Laravel\Screen::active()`
