### PR TITLE
Fix: incorrect namespace for VerifyCsrfToken middleware

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,11 +1,11 @@
 <?php
 
-use App\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
-use Native\Laravel\Http\Controllers\CreateSecurityCookieController;
-use Native\Laravel\Http\Controllers\DispatchEventFromAppController;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Native\Laravel\Http\Controllers\NativeAppBootedController;
 use Native\Laravel\Http\Middleware\PreventRegularBrowserAccess;
+use Native\Laravel\Http\Controllers\CreateSecurityCookieController;
+use Native\Laravel\Http\Controllers\DispatchEventFromAppController;
 
 Route::group(['middleware' => PreventRegularBrowserAccess::class], function () {
     Route::post('_native/api/booted', NativeAppBootedController::class);


### PR DESCRIPTION
The nativephp/laravel/routes/api.php file references App\Http\Middleware\VerifyCsrfToken, which doesn't exist. Updated the namespace to the correct path: Illuminate\Foundation\Http\Middleware\VerifyCsrfToken