### PR TITLE
Implement default config for pre and post build commands

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -125,4 +125,15 @@ return [
             'timeout' => 60,
         ],
     ],
+
+    /**
+     * Define your own scripts to run before and after the build process.
+     */
+    'prebuild' => [
+        // 'npm run build',
+    ],
+
+    'postbuild' => [
+        // 'rm -rf public/build',
+    ],
 ];


### PR DESCRIPTION
Accompanies https://github.com/NativePHP/electron/pull/167

This pull request includes changes to the `config/nativephp.php` file to allow for the definition of custom scripts to run before and after the build process.

Build process customization:

* [`config/nativephp.php`](diffhunk://#diff-fdcd0451c3e5f10d1c3e5148c2e6e691338cb547e4eb67c570b2627d9b6e043eR128-R138): Added `prebuild` and `postbuild` configuration options to define custom scripts to run before and after the build process.