### PR TITLE
feat: implement Alert class and facade for alert management

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -53,20 +53,6 @@ class Alert
         return $this;
     }
 
-    public function defaultPath(string $defaultPath): self
-    {
-        $this->defaultPath = $defaultPath;
-
-        return $this;
-    }
-
-    public function button(string $buttonLabel): self
-    {
-        $this->buttonLabel = $buttonLabel;
-
-        return $this;
-    }
-
     public function defaultId(int $defaultId): self
     {
         $this->defaultId = $defaultId;

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Native\Laravel;
+
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use Native\Laravel\Client\Client;
+use Native\Laravel\Facades\Window;
+
+class Alert
+{
+    protected ?string $type;
+    protected ?string $title;
+    protected ?string $detail;
+    protected ?array $buttons;
+    protected ?int $defaultId;
+    protected ?int $cancelId;
+
+    final public function __construct(protected Client $client)
+    {
+    }
+
+    public static function new()
+    {
+        return new static(new Client);
+    }
+
+    public function type(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function title(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function detail(string $detail): self
+    {
+        $this->detail = $detail;
+
+        return $this;
+    }
+
+    public function buttons(array $buttons): self
+    {
+        $this->buttons = $buttons;
+
+        return $this;
+    }
+
+    public function defaultPath(string $defaultPath): self
+    {
+        $this->defaultPath = $defaultPath;
+
+        return $this;
+    }
+
+    public function button(string $buttonLabel): self
+    {
+        $this->buttonLabel = $buttonLabel;
+
+        return $this;
+    }
+
+    public function defaultId(int $defaultId): self
+    {
+        $this->defaultId = $defaultId;
+
+        return $this;
+    }
+
+    public function cancelId(int $cancelId): self
+    {
+        $this->cancelId = $cancelId;
+
+        return $this;
+    }
+
+    public function show(string $message): int
+    {
+        $response = $this->client->post('alert/message', [
+            'message' => $message,
+            'type' => $this->type,
+            'title' => $this->title,
+            'detail' => $this->detail,
+            'buttons' => $this->buttons,
+            'defaultId' => $this->defaultId,
+            'cancelId' => $this->cancelId
+        ]);
+
+        return (int) $response->json('result');
+    }
+
+    public function error(string $title, string $message): bool
+    {
+        $response = $this->client->post('alert/error', [
+            'title' => $title,
+            'message' => $message,
+        ]);
+
+        return (bool) $response->json('result');
+    }
+}

--- a/src/Facades/Alert.php
+++ b/src/Facades/Alert.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Native\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static static type(string $type)
+ * @method static static title(string $title)
+ * @method static static detail(string $detail)
+ * @method static static buttons(string[] $buttons)
+ * @method static static defaultId(int $defaultId)
+ * @method static static cancelId(int $cancelId)
+ * @method static int show(string $message)
+ * @method static bool error(string $title, string $message)
+ */
+class Alert extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \Native\Laravel\Alert::class;
+    }
+}


### PR DESCRIPTION
I saw that there were remnants of the Electron-MessageBox Api. I removed the remnants from the dialog and created a new class “Alert”.

PR: NativePHP/electron
https://github.com/NativePHP/electron/pull/184