### PR TITLE
Fixed error "method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given" when using Livewire and AdminLTE.

### DIFF
--- a/src/Events/EventWatcher.php
+++ b/src/Events/EventWatcher.php
@@ -12,7 +12,11 @@ class EventWatcher
     public function register(): void
     {
         Event::listen('*', function (string $eventName, array $data) {
-            $event = (object)($data[0] ?? null);
+            $event = $data[0] ?? (object) null;
+
+            if(! is_object($event)) {
+                return;
+            }
 
             if (! method_exists($event, 'broadcastOn')) {
                 return;

--- a/src/Events/EventWatcher.php
+++ b/src/Events/EventWatcher.php
@@ -12,7 +12,7 @@ class EventWatcher
     public function register(): void
     {
         Event::listen('*', function (string $eventName, array $data) {
-            $event = $data[0] ?? (object) null;
+            $event = (object)($data[0] ?? null);
 
             if (! method_exists($event, 'broadcastOn')) {
                 return;


### PR DESCRIPTION
I made the changes mentioned in the issue #517. That the exception "method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given" from being thrown.