### PR TITLE
Environment Helper

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -2,23 +2,23 @@
 
 namespace Native\Laravel;
 
-use Illuminate\Support\Traits\Conditionable;
-use Illuminate\Support\Traits\Macroable;
 use Native\Laravel\Client\Client;
-use Native\Laravel\Facades\Window;
 
 class Alert
 {
     protected ?string $type;
+
     protected ?string $title;
+
     protected ?string $detail;
+
     protected ?array $buttons;
+
     protected ?int $defaultId;
+
     protected ?int $cancelId;
 
-    final public function __construct(protected Client $client)
-    {
-    }
+    final public function __construct(protected Client $client) {}
 
     public static function new()
     {
@@ -76,7 +76,7 @@ class Alert
             'detail' => $this->detail,
             'buttons' => $this->buttons,
             'defaultId' => $this->defaultId,
-            'cancelId' => $this->cancelId
+            'cancelId' => $this->cancelId,
         ]);
 
         return (int) $response->json('result');

--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
-
 use Native\Laravel\Support\Environment;
+
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\intro;

--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 
+use Native\Laravel\Support\Environment;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\intro;
@@ -53,7 +54,7 @@ class DebugCommand extends Command implements PromptsForMissingInput
     {
         $locationCommand = 'which';
 
-        if (PHP_OS_FAMILY === 'Windows') {
+        if (Environment::isWindows()) {
             $locationCommand = 'where';
         }
 
@@ -154,9 +155,9 @@ class DebugCommand extends Command implements PromptsForMissingInput
         $json = json_encode($this->debugInfo->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
         // Copy json to clipboard
-        if (PHP_OS_FAMILY === 'Windows') {
+        if (Environment::isWindows()) {
             Process::run('echo '.escapeshellarg($json).' | clip');
-        } elseif (PHP_OS_FAMILY === 'Linux') {
+        } elseif (Environment::isLinux()) {
             Process::run('echo '.escapeshellarg($json).' | xclip -selection clipboard');
         } else {
             Process::run('echo '.escapeshellarg($json).' | pbcopy');

--- a/src/Events/EventWatcher.php
+++ b/src/Events/EventWatcher.php
@@ -14,7 +14,7 @@ class EventWatcher
         Event::listen('*', function (string $eventName, array $data) {
             $event = $data[0] ?? (object) null;
 
-            if(! is_object($event)) {
+            if (! is_object($event)) {
                 return;
             }
 

--- a/src/Support/Environment.php
+++ b/src/Support/Environment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Native\Laravel\Support;
+
+class Environment
+{
+    public static function isWindows(): bool
+    {
+        return PHP_OS_FAMILY === 'Windows';
+    }
+
+    public static function isLinux(): bool
+    {
+        return PHP_OS_FAMILY === 'Linux';
+    }
+
+    public static function isMac(): bool
+    {
+        return PHP_OS_FAMILY === 'Darwin';
+    }
+
+    public static function isUnknown(): bool
+    {
+        return PHP_OS_FAMILY === 'Unknown';
+    }
+
+    public static function isUnixLike(): bool
+    {
+        return static::isLinux() || static::isMac();
+    }
+}

--- a/src/System.php
+++ b/src/System.php
@@ -4,6 +4,7 @@ namespace Native\Laravel;
 
 use Native\Laravel\Client\Client;
 use Native\Laravel\DataObjects\Printer;
+use Native\Laravel\Support\Environment;
 use Native\Laravel\Support\Timezones;
 
 class System
@@ -79,7 +80,7 @@ class System
     {
         $timezones = new Timezones;
 
-        if (PHP_OS_FAMILY === 'Windows') {
+        if (Environment::isWindows()) {
             $timezone = $timezones->translateFromWindowsString(exec('tzutil /g'));
         } else {
             $timezone = $timezones->translateFromAbbreviatedString(exec('date +%Z'));


### PR DESCRIPTION
This pull request focuses on refactoring the code to use a new `Environment` class for determining the operating system, improving readability and maintainability. The most important changes include the introduction of the `Environment` class and its integration into existing methods.

Introduction of the `Environment` class:

* [`src/Support/Environment.php`](diffhunk://#diff-36e0d8443cf74a7cc48d8a98259de09d10e12133e708b5ccb330ac1202dd3545R1-R31): Added a new `Environment` class with methods to check the current operating system (`isWindows`, `isLinux`, `isMac`, `isUnknown`, `isUnixLike`).

Integration of the `Environment` class:

* [`src/Commands/DebugCommand.php`](diffhunk://#diff-8fabe4acd896091d75c0bc65620bef8558c9f0f67378aad9a7e8fb77a389bacfL56-R57): Replaced checks for `PHP_OS_FAMILY` with calls to the new `Environment` class methods in `processEnvironment` and `outputToClipboard` functions. [[1]](diffhunk://#diff-8fabe4acd896091d75c0bc65620bef8558c9f0f67378aad9a7e8fb77a389bacfL56-R57) [[2]](diffhunk://#diff-8fabe4acd896091d75c0bc65620bef8558c9f0f67378aad9a7e8fb77a389bacfL157-R160)
* [`src/System.php`](diffhunk://#diff-692573c06d44b88f8f69b864c7dad57659d7513b8c2705c0e699fd0a6bec8dc6L82-R83): Updated the `timezone` function to use `Environment::isWindows` instead of checking `PHP_OS_FAMILY`.

Additional updates to import the `Environment` class:

* [`src/Commands/DebugCommand.php`](diffhunk://#diff-8fabe4acd896091d75c0bc65620bef8558c9f0f67378aad9a7e8fb77a389bacfR12): Added import for `Native\Laravel\Support\Environment`.
* [`src/System.php`](diffhunk://#diff-692573c06d44b88f8f69b864c7dad57659d7513b8c2705c0e699fd0a6bec8dc6R7): Added import for `Native\Laravel\Support\Environment`.