### PR TITLE
PHP Support Sync

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,15 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.4, 8.3]
         laravel: [12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
-
-        exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16.4",
         "symfony/finder": "^6.2|^7.0"


### PR DESCRIPTION
This pull request includes changes to the PHP version requirements and the testing matrix configuration. The most important changes include updating the PHP version requirements in `composer.json` and modifying the testing matrix in the GitHub Actions workflow.

Changes to PHP version requirements:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L34-R34): Updated the required PHP version to `^8.3` from `^8.1`.

Changes to testing matrix configuration:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L16-L25): Modified the PHP versions in the matrix to only include `8.4` and `8.3`, and removed exclusions for Laravel versions `11.*` and `12.*` with PHP `8.1`.