### PR TITLE
fix: resolve ChildProcess dynamic property warnings

### DIFF
--- a/src/ChildProcess.php
+++ b/src/ChildProcess.php
@@ -19,6 +19,8 @@ class ChildProcess implements ChildProcessContract
 
     public readonly bool $persistent;
 
+    protected array $settings = [];
+
     final public function __construct(protected Client $client) {}
 
     public function get(?string $alias = null): ?self
@@ -146,10 +148,13 @@ class ChildProcess implements ChildProcessContract
             $this->pid = $process['pid'];
         }
 
-        foreach ($process['settings'] as $key => $value) {
-            $this->{$key} = $value;
-        }
+        $this->settings = $process['settings'] ?? [];
 
         return $this;
+    }
+
+    public function __get($name)
+    {
+        return $this->settings[$name] ?? null;
     }
 }

--- a/tests/ChildProcess/ChildProcessTest.php
+++ b/tests/ChildProcess/ChildProcessTest.php
@@ -6,121 +6,143 @@ use Native\Laravel\ChildProcess as ChildProcessImplement;
 use Native\Laravel\Client\Client;
 use Native\Laravel\Facades\ChildProcess;
 
-beforeEach(function () {
-    Http::fake();
+describe('API', function () {
+    beforeEach(function () {
+        Http::fake();
 
-    $mock = Mockery::mock(ChildProcessImplement::class, [resolve(Client::class)])
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
+        $mock = Mockery::mock(ChildProcessImplement::class, [resolve(Client::class)])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
 
-    $this->instance(ChildProcessImplement::class, $mock->allows([
-        'fromRuntimeProcess' => $mock,
-    ]));
-});
+        $this->instance(ChildProcessImplement::class, $mock->allows([
+            'fromRuntimeProcess' => $mock,
+        ]));
+    });
 
-it('can start a child process', function () {
-    ChildProcess::start('foo bar', 'some-alias', 'path/to/dir', ['baz' => 'zah']);
+    it('can start a child process', function () {
+        ChildProcess::start('foo bar', 'some-alias', 'path/to/dir', ['baz' => 'zah']);
 
-    Http::assertSent(function (Request $request) {
-        return $request->url() === 'http://localhost:4000/api/child-process/start' &&
-               $request['alias'] === 'some-alias' &&
-               $request['cmd'] === ['foo bar'] &&
-               $request['cwd'] === 'path/to/dir' &&
-               $request['env'] === ['baz' => 'zah'];
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'http://localhost:4000/api/child-process/start' &&
+                $request['alias'] === 'some-alias' &&
+                $request['cmd'] === ['foo bar'] &&
+                $request['cwd'] === 'path/to/dir' &&
+                $request['env'] === ['baz' => 'zah'];
+        });
+    });
+
+    it('can start a php command', function () {
+        ChildProcess::php("-r 'sleep(5);'", 'some-alias', ['baz' => 'zah']);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'http://localhost:4000/api/child-process/start-php' &&
+                $request['alias'] === 'some-alias' &&
+                $request['cmd'] === ["-r 'sleep(5);'"] &&
+                $request['cwd'] === base_path() &&
+                $request['env'] === ['baz' => 'zah'];
+        });
+    });
+
+    it('can start a artisan command', function () {
+        ChildProcess::artisan('foo:bar --verbose', 'some-alias', ['baz' => 'zah']);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'http://localhost:4000/api/child-process/start-php' &&
+                $request['alias'] === 'some-alias' &&
+                $request['cmd'] === ['artisan', 'foo:bar --verbose'] &&
+                $request['cwd'] === base_path() &&
+                $request['env'] === ['baz' => 'zah'];
+        });
+    });
+
+    it('accepts either a string or a array as start command argument', function () {
+        ChildProcess::start('foo bar', 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cmd'] === ['foo bar']);
+
+        ChildProcess::start(['foo', 'baz'], 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cmd'] === ['foo', 'baz']);
+    });
+
+    it('accepts either a string or a array as php command argument', function () {
+        ChildProcess::php("-r 'sleep(5);'", 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cmd'] === ["-r 'sleep(5);'"]);
+
+        ChildProcess::php(['-r', "'sleep(5);'"], 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cmd'] === ['-r', "'sleep(5);'"]);
+    });
+
+    it('accepts either a string or a array as artisan command argument', function () {
+        ChildProcess::artisan('foo:bar', 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cmd'] === ['artisan', 'foo:bar']);
+
+        ChildProcess::artisan(['foo:baz'], 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cmd'] === ['artisan', 'foo:baz']);
+    });
+
+    it('sets the cwd to the base path if none was given', function () {
+        ChildProcess::start(['foo', 'bar'], 'some-alias', cwd: 'path/to/dir');
+        Http::assertSent(fn(Request $request) => $request['cwd'] === 'path/to/dir');
+
+        ChildProcess::start(['foo', 'bar'], 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['cwd'] === base_path());
+    });
+
+    it('can stop a child process', function () {
+        ChildProcess::stop('some-alias');
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'http://localhost:4000/api/child-process/stop' &&
+                $request['alias'] === 'some-alias';
+        });
+    });
+
+    it('can send messages to a child process', function () {
+        ChildProcess::message('some-message', 'some-alias');
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'http://localhost:4000/api/child-process/message' &&
+                $request['alias'] === 'some-alias' &&
+                $request['message'] === 'some-message';
+        });
+    });
+
+    it('can mark a process as persistent', function () {
+        ChildProcess::start('foo bar', 'some-alias', persistent: true);
+        Http::assertSent(fn(Request $request) => $request['persistent'] === true);
+    });
+
+    it('can mark a php command as persistent', function () {
+        ChildProcess::php("-r 'sleep(5);'", 'some-alias', persistent: true);
+        Http::assertSent(fn(Request $request) => $request['persistent'] === true);
+    });
+
+    it('can mark a artisan command as persistent', function () {
+        ChildProcess::artisan('foo:bar', 'some-alias', persistent: true);
+        Http::assertSent(fn(Request $request) => $request['persistent'] === true);
+    });
+
+    it('marks the process as non-persistent by default', function () {
+        ChildProcess::start('foo bar', 'some-alias');
+        Http::assertSent(fn(Request $request) => $request['persistent'] === false);
     });
 });
 
-it('can start a php command', function () {
-    ChildProcess::php("-r 'sleep(5);'", 'some-alias', ['baz' => 'zah']);
+describe('Hydration', function () {
+    it('hydrates runtime properties from API responses', function () {
+        $processData = [
+            'pid' => 1234,
+            'settings' => [
+                'iniSettings' => ['memory_limit' => '256M'],
+            ],
+        ];
+        Http::fake([
+            'http://localhost:4000/api/child-process/start-php' => Http::response($processData, 200),
+        ]);
 
-    Http::assertSent(function (Request $request) {
-        return $request->url() === 'http://localhost:4000/api/child-process/start-php' &&
-               $request['alias'] === 'some-alias' &&
-               $request['cmd'] === ["-r 'sleep(5);'"] &&
-               $request['cwd'] === base_path() &&
-               $request['env'] === ['baz' => 'zah'];
+        $childProcess = new ChildProcessImplement(resolve(Client::class));
+
+        $result = $childProcess->php("-r 'sleep(5);'", 'some-alias');
+        expect($result->pid)->toBe(1234);
+        expect($result->iniSettings)->toBe(['memory_limit' => '256M']);
     });
-});
-
-it('can start a artisan command', function () {
-    ChildProcess::artisan('foo:bar --verbose', 'some-alias', ['baz' => 'zah']);
-
-    Http::assertSent(function (Request $request) {
-        return $request->url() === 'http://localhost:4000/api/child-process/start-php' &&
-               $request['alias'] === 'some-alias' &&
-               $request['cmd'] === ['artisan', 'foo:bar --verbose'] &&
-               $request['cwd'] === base_path() &&
-               $request['env'] === ['baz' => 'zah'];
-    });
-});
-
-it('accepts either a string or a array as start command argument', function () {
-    ChildProcess::start('foo bar', 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo bar']);
-
-    ChildProcess::start(['foo', 'baz'], 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['foo', 'baz']);
-});
-
-it('accepts either a string or a array as php command argument', function () {
-    ChildProcess::php("-r 'sleep(5);'", 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ["-r 'sleep(5);'"]);
-
-    ChildProcess::php(['-r', "'sleep(5);'"], 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['-r', "'sleep(5);'"]);
-});
-
-it('accepts either a string or a array as artisan command argument', function () {
-    ChildProcess::artisan('foo:bar', 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['artisan', 'foo:bar']);
-
-    ChildProcess::artisan(['foo:baz'], 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cmd'] === ['artisan', 'foo:baz']);
-});
-
-it('sets the cwd to the base path if none was given', function () {
-    ChildProcess::start(['foo', 'bar'], 'some-alias', cwd: 'path/to/dir');
-    Http::assertSent(fn (Request $request) => $request['cwd'] === 'path/to/dir');
-
-    ChildProcess::start(['foo', 'bar'], 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['cwd'] === base_path());
-});
-
-it('can stop a child process', function () {
-    ChildProcess::stop('some-alias');
-
-    Http::assertSent(function (Request $request) {
-        return $request->url() === 'http://localhost:4000/api/child-process/stop' &&
-               $request['alias'] === 'some-alias';
-    });
-});
-
-it('can send messages to a child process', function () {
-    ChildProcess::message('some-message', 'some-alias');
-
-    Http::assertSent(function (Request $request) {
-        return $request->url() === 'http://localhost:4000/api/child-process/message' &&
-               $request['alias'] === 'some-alias' &&
-               $request['message'] === 'some-message';
-    });
-});
-
-it('can mark a process as persistent', function () {
-    ChildProcess::start('foo bar', 'some-alias', persistent: true);
-    Http::assertSent(fn (Request $request) => $request['persistent'] === true);
-});
-
-it('can mark a php command as persistent', function () {
-    ChildProcess::php("-r 'sleep(5);'", 'some-alias', persistent: true);
-    Http::assertSent(fn (Request $request) => $request['persistent'] === true);
-});
-
-it('can mark a artisan command as persistent', function () {
-    ChildProcess::artisan('foo:bar', 'some-alias', persistent: true);
-    Http::assertSent(fn (Request $request) => $request['persistent'] === true);
-});
-
-it('marks the process as non-persistent by default', function () {
-    ChildProcess::start('foo bar', 'some-alias');
-    Http::assertSent(fn (Request $request) => $request['persistent'] === false);
 });


### PR DESCRIPTION
-  Implement __get magic method for settings access
-  Add test verification for property hydration
-  Remove direct dynamic property assignments

Addresses this warning

> [warning] Creation of dynamic property Native\Laravel\ChildProcess::$iniSettings is deprecated in /Users/kevin/code/native/mcp-manager/vendor/nativephp/laravel/src/ChildProcess.php on line 150 []

For the test, I had to scope them to bypass the mock, so each line has an indentation update. The only change in that file is 
```php
describe('Hydration', function () {
    it('hydrates runtime properties from API responses', function () {
        $processData = [
            'pid' => 1234,
            'settings' => [
                'iniSettings' => ['memory_limit' => '256M'],
            ],
        ];
        Http::fake([
            'http://localhost:4000/api/child-process/start-php' => Http::response($processData, 200),
        ]);

        $childProcess = new ChildProcessImplement(resolve(Client::class));

        $result = $childProcess->php("-r 'sleep(5);'", 'some-alias');
        expect($result->pid)->toBe(1234);
        expect($result->iniSettings)->toBe(['memory_limit' => '256M']);
    });
});
```