### PR TITLE
Remove L10 from test matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -51,7 +51,6 @@ class NativeServiceProvider extends PackageServiceProvider
         $this->mergeConfigFrom($this->package->basePath('/../config/nativephp-internal.php'), 'nativephp-internal');
 
         $this->app->singleton(FreshCommand::class, function ($app) {
-            /* @phpstan-ignore-next-line (beacause we support Laravel 10 & 11) */
             return new FreshCommand($app['migrator']);
         });
 


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to update the test matrix for Laravel versions.

Changes in `.github/workflows/run-tests.yml`:

* Removed support for Laravel 10.x from the test matrix.