### PR TITLE
Reduce number of fields on bug report, replacing many with native:debug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,8 +7,10 @@ body:
       attributes:
           value: |
               We're sorry to hear you have a problem.
-              
+
               Before submitting your report, please make sure you've been through the section "[Debugging](https://nativephp.com/docs/getting-started/debugging)" in the docs.
+
+              Please also ensure that you have the latest version of NativePHP packages installed, and are using [supported versions](https://nativephp.com/docs/desktop/1/getting-started/support-policy) of PHP and Laravel.
 
               If nothing here has helped you, please provide as much useful context as you can here to help us solve help you.
 
@@ -23,6 +25,7 @@ body:
           placeholder: Trying to build my app for production
       validations:
           required: true
+
     - type: textarea
       id: what-happened
       attributes:
@@ -31,6 +34,7 @@ body:
           placeholder: I cannot currently do X thing because when I do, it breaks X thing.
       validations:
           required: true
+
     - type: textarea
       id: how-to-reproduce
       attributes:
@@ -39,37 +43,15 @@ body:
           placeholder: When I do X I see Y.
       validations:
           required: true
+
     - type: textarea
-      id: package-version
+      id: debug
       attributes:
-          label: Package Versions
-          description: What versions of the NativePHP packages are you running? Output of `composer show "nativephp/*" --format=json`
+          label: Debug Output
+          description: Please provide output from the NativePHP Debug command. This will help us understand your environment and the issue you're facing. (`php artisan native:debug`)
       validations:
           required: true
-    - type: input
-      id: php-version
-      attributes:
-          label: PHP Version
-          description: What version of PHP are you running? Please be as specific as possible
-          placeholder: 8.2.0
-      validations:
-          required: true
-    - type: input
-      id: laravel-version
-      attributes:
-        label: Laravel Version
-        description: What version of Laravel are you running? Please be as specific as possible
-        placeholder: 9.0.0
-      validations:
-        required: true
-    - type: input
-      id: node-version
-      attributes:
-        label: Node Version
-        description: What version of Node are you running? Please be as specific as possible
-        placeholder: '18.17'
-      validations:
-        required: true
+
     - type: dropdown
       id: operating-systems
       attributes:
@@ -80,14 +62,7 @@ body:
         - macOS
         - Windows
         - Linux
-    - type: input
-      id: os-version
-      attributes:
-        label: OS version
-        description: Which version of these OSes are you using?
-        placeholder: 'win11 (23H2), macos14.1 (23B74)'
-      validations:
-        required: true
+
     - type: textarea
       id: notes
       attributes:


### PR DESCRIPTION
This pull request includes several updates to the bug report issue template in the `.github/ISSUE_TEMPLATE/bug.yml` file to improve the clarity and usefulness of the information collected.

### Updates to bug report issue template:

* Added a reminder for users to ensure they have the latest version of NativePHP packages and are using supported versions of PHP and Laravel.
* Removed fields for package versions, OS version, PHP version, Laravel version, and Node version, and replaced them with a `textarea` for debug output from the NativePHP Debug command.