### PR TITLE
Add more info to `artisan native:debug`

### DIFF
--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -66,7 +66,8 @@ class DebugCommand extends Command implements PromptsForMissingInput
             ],
             'Laravel' => [
                 'Version' => app()->version(),
-                'ConfigCached' => file_exists($this->laravel->getCachedConfigPath()),
+                'ConfigCached' => $this->laravel->configurationIsCached(),
+                'RoutesCached' => $this->laravel->routesAreCached(),
                 'DebugEnabled' => $this->laravel->hasDebugModeEnabled(),
             ],
             'Node' => [


### PR DESCRIPTION
- Add check if routes are cached. It's useful when supporting others, won't need to ask if routes are cached by any chance.
- Change config check to use what `artisan about` uses.