### PR TITLE
Automatically apply PreventBrowserAccess middleware

### DIFF
--- a/src/Http/Middleware/PreventRegularBrowserAccess.php
+++ b/src/Http/Middleware/PreventRegularBrowserAccess.php
@@ -9,7 +9,7 @@ class PreventRegularBrowserAccess
 {
     public function handle(Request $request, Closure $next)
     {
-        if (app()->runningUnitTests()) {
+        if (! config('nativephp-internal.running')) {
             return $next($request);
         }
 

--- a/src/Http/Middleware/PreventRegularBrowserAccess.php
+++ b/src/Http/Middleware/PreventRegularBrowserAccess.php
@@ -9,6 +9,10 @@ class PreventRegularBrowserAccess
 {
     public function handle(Request $request, Closure $next)
     {
+        if (app()->runningUnitTests()) {
+            return $next($request);
+        }
+
         // Explicitly skip for the cookie-setting route
         if ($request->path() === '_native/api/cookie') {
             return $next($request);

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -4,6 +4,7 @@ namespace Native\Laravel;
 
 use Illuminate\Console\Application;
 use Illuminate\Foundation\Application as Foundation;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -23,6 +24,7 @@ use Native\Laravel\DTOs\QueueConfig;
 use Native\Laravel\Events\EventWatcher;
 use Native\Laravel\Exceptions\Handler;
 use Native\Laravel\GlobalShortcut as GlobalShortcutImplementation;
+use Native\Laravel\Http\Middleware\PreventRegularBrowserAccess;
 use Native\Laravel\Logging\LogWatcher;
 use Native\Laravel\PowerMonitor as PowerMonitorImplementation;
 use Native\Laravel\Windows\WindowManager as WindowManagerImplementation;
@@ -83,6 +85,11 @@ class NativeServiceProvider extends PackageServiceProvider
                 \Illuminate\Contracts\Debug\ExceptionHandler::class,
                 Handler::class
             );
+
+            // Automatically prevent browser access
+            $this->app->make(Router::class)->pushMiddlewareToGroup('web', [
+                PreventRegularBrowserAccess::class,
+            ]);
 
             Application::starting(function ($app) {
                 $app->resolveCommands([

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -4,7 +4,7 @@ namespace Native\Laravel;
 
 use Illuminate\Console\Application;
 use Illuminate\Foundation\Application as Foundation;
-use Illuminate\Routing\Router;
+use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -87,9 +87,9 @@ class NativeServiceProvider extends PackageServiceProvider
             );
 
             // Automatically prevent browser access
-            $this->app->make(Router::class)->pushMiddlewareToGroup('web', [
+            $this->app->make(Kernel::class)->pushMiddleware(
                 PreventRegularBrowserAccess::class,
-            ]);
+            );
 
             Application::starting(function ($app) {
                 $app->resolveCommands([


### PR DESCRIPTION
The PreventBrowserAccess middleware causes browser tests to fail with 403's. This PR adds a simple guard clause that skips the middleware when it detects it's running tests.