### PR TITLE
Updated `Settings::get` Method to Handle `$default` as Closure

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -17,7 +17,13 @@ class Settings
 
     public function get(string $key, $default = null): mixed
     {
-        return $this->client->get('settings/'.$key)->json('value') ?? $default;
+        $response = $this->client->get('settings/'.$key)->json('value');
+
+        if ($response === null) {
+            return $default instanceof \Closure ? $default() : $default;
+        }
+
+        return $response;
     }
 
     public function forget(string $key): void


### PR DESCRIPTION
Starting to use NativePHP. This PR aims to allow `Settings::get` to handle the `$default` value as a closure.