### PR TITLE
Added `has` method to `Settings` class

### DIFF
--- a/src/Facades/Settings.php
+++ b/src/Facades/Settings.php
@@ -7,12 +7,15 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static void set(string $key, $value)
  * @method static mixed get(string $key, $default = null)
+ * @method static bool has(string $key)
  * @method static void forget(string $key)
  * @method static void clear()
+ *
+ * @see \Native\Laravel\Settings
  */
 class Settings extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return \Native\Laravel\Settings::class;
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -8,6 +8,13 @@ class Settings
 {
     public function __construct(protected Client $client) {}
 
+    /**
+     * Set a value in the settings using the provided key.
+     *
+     * @param string $key
+     * @param $value
+     * @return void
+     */
     public function set(string $key, $value): void
     {
         $this->client->post('settings/'.$key, [
@@ -15,21 +22,48 @@ class Settings
         ]);
     }
 
+    /**
+     * Retrieve a value from the settings using the provided key.
+     *
+     * @param string $key
+     * @param mixed|null $default
+     *
+     * @return mixed
+     */
     public function get(string $key, $default = null): mixed
     {
         return $this->client->get('settings/'.$key)->json('value') ?? $default;
     }
 
+    /**
+     * Determine if a value exists in the settings for the provided key.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
     public function has(string $key): bool
     {
         return $this->client->get('settings/'.$key)->json('value') !== null;
     }
 
+    /**
+     * Remove a value from the settings using the provided key.
+     *
+     * @param string $key
+     *
+     * @return void
+     */
     public function forget(string $key): void
     {
         $this->client->delete('settings/'.$key);
     }
 
+    /**
+     * Clear all settings by deleting them from the storage.
+     *
+     * @return void
+     */
     public function clear(): void
     {
         $this->client->delete('settings/');

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -20,6 +20,11 @@ class Settings
         return $this->client->get('settings/'.$key)->json('value') ?? $default;
     }
 
+    public function has(string $key): bool
+    {
+        return $this->client->get('settings/'.$key)->json('value') !== null;
+    }
+
     public function forget(string $key): void
     {
         $this->client->delete('settings/'.$key);


### PR DESCRIPTION
This PR aims to introduce a method called `has` that can be used to check if a given configuration is set. 

This is similar to get, the difference is that we apply a `!== null` to the obtained value.