### PR TITLE
Include sleep option in queue config 

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -141,6 +141,7 @@ return [
             'queues' => ['default'],
             'memory_limit' => 128,
             'timeout' => 60,
+            'sleep' => 3,
         ],
     ],
 

--- a/src/DTOs/QueueConfig.php
+++ b/src/DTOs/QueueConfig.php
@@ -12,6 +12,7 @@ class QueueConfig
         public readonly array $queuesToConsume,
         public readonly int $memoryLimit,
         public readonly int $timeout,
+        public readonly int $sleep,
     ) {}
 
     /**
@@ -26,6 +27,7 @@ class QueueConfig
                     $worker['queues'] ?? ['default'],
                     $worker['memory_limit'] ?? 128,
                     $worker['timeout'] ?? 60,
+                    $worker['sleep'] ?? 3,
                 );
             },
             $config,

--- a/src/QueueWorker.php
+++ b/src/QueueWorker.php
@@ -31,6 +31,7 @@ class QueueWorker implements QueueWorkerContract
                 '--queue='.implode(',', $config->queuesToConsume),
                 "--memory={$config->memoryLimit}",
                 "--timeout={$config->timeout}",
+                "--sleep={$config->sleep}",
             ],
             'queue_'.$config->alias,
             persistent: true,

--- a/tests/DTOs/QueueWorkerTest.php
+++ b/tests/DTOs/QueueWorkerTest.php
@@ -21,6 +21,8 @@ test('the factory method generates an array of config objects for several format
                 fn (QueueConfig $config) => $config->alias === $worker)))->memoryLimit->toBe(128);
             expect(Arr::first(array_filter($configObject,
                 fn (QueueConfig $config) => $config->alias === $worker)))->timeout->toBe(60);
+            expect(Arr::first(array_filter($configObject,
+                fn (QueueConfig $config) => $config->alias === $worker)))->sleep->toBe(3);
 
             continue;
         }
@@ -35,6 +37,8 @@ test('the factory method generates an array of config objects for several format
             fn (QueueConfig $config) => $config->alias === $alias)))->memoryLimit->toBe($worker['memory_limit'] ?? 128);
         expect(Arr::first(array_filter($configObject,
             fn (QueueConfig $config) => $config->alias === $alias)))->timeout->toBe($worker['timeout'] ?? 60);
+        expect(Arr::first(array_filter($configObject,
+            fn (QueueConfig $config) => $config->alias === $alias)))->sleep->toBe($worker['sleep'] ?? 3);
     }
 })->with([
     [
@@ -44,6 +48,7 @@ test('the factory method generates an array of config objects for several format
                     'queues' => ['default'],
                     'memory_limit' => 64,
                     'timeout' => 60,
+                    'sleep' => 3,
                 ],
             ],
         ],

--- a/tests/Fakes/FakeQueueWorkerTest.php
+++ b/tests/Fakes/FakeQueueWorkerTest.php
@@ -17,8 +17,8 @@ it('swaps implementations using facade', function () {
 it('asserts up using callable', function () {
     swap(QueueWorkerContract::class, $fake = app(QueueWorkerFake::class));
 
-    $fake->up(new QueueConfig('testA', ['default'], 123, 123));
-    $fake->up(new QueueConfig('testB', ['default'], 123, 123));
+    $fake->up(new QueueConfig('testA', ['default'], 123, 123, 0));
+    $fake->up(new QueueConfig('testB', ['default'], 123, 123, 0));
 
     $fake->assertUp(fn (QueueConfig $up) => $up->alias === 'testA');
     $fake->assertUp(fn (QueueConfig $up) => $up->alias === 'testB');

--- a/tests/QueueWorker/QueueWorkerTest.php
+++ b/tests/QueueWorker/QueueWorkerTest.php
@@ -9,7 +9,7 @@ it('hits the child process with relevant queue config to spin up a new queue wor
 
     $workerName = 'some_worker';
 
-    $config = new QueueConfig($workerName, ['default'], 128, 61);
+    $config = new QueueConfig($workerName, ['default'], 128, 61, 5);
 
     QueueWorker::up($config);
 
@@ -20,6 +20,7 @@ it('hits the child process with relevant queue config to spin up a new queue wor
             '--queue=default',
             '--memory=128',
             '--timeout=61',
+            '--sleep=5',
         ]);
 
         expect($iniSettings)->toBe([


### PR DESCRIPTION
This PR exposes the sleep argument for the `queue:work` command. The motivation behind this change is to reduce the delay between dispatching an asynchronous job and a worker picking it up. This delay can create a noticeable lag in the UI, which I'm currently experiencing. In my case, setting sleep=0 resolves the issue.