### PR TITLE
Add "showOnAllWorkspaces" option to MenuBar

### DIFF
--- a/src/MenuBar/MenuBar.php
+++ b/src/MenuBar/MenuBar.php
@@ -32,6 +32,8 @@ class MenuBar
 
     protected bool $showDockIcon = false;
 
+    protected bool $showOnAllWorkspaces = false;
+
     protected Client $client;
 
     public function __construct()
@@ -95,6 +97,13 @@ class MenuBar
         return $this;
     }
 
+    public function showOnAllWorkspaces($showOnAllWorkspaces = true): self
+    {
+        $this->showOnAllWorkspaces = $showOnAllWorkspaces;
+
+        return $this;
+    }
+
     public function withContextMenu(Menu $menu): self
     {
         $this->contextMenu = $menu;
@@ -122,6 +131,7 @@ class MenuBar
             'onlyShowContextMenu' => $this->onlyShowContextMenu,
             'contextMenu' => ! is_null($this->contextMenu) ? $this->contextMenu->toArray()['submenu'] : null,
             'alwaysOnTop' => $this->alwaysOnTop,
+            'showOnAllWorkspaces' => $this->showOnAllWorkspaces,
         ];
     }
 }

--- a/tests/MenuBar/MenuBarTest.php
+++ b/tests/MenuBar/MenuBarTest.php
@@ -9,6 +9,7 @@ it('menubar with create', function () {
     $menuBar = MenuBar::create()
         ->showDockIcon()
         ->alwaysOnTop()
+        ->showOnAllWorkspaces()
         ->label('milwad')
         ->icon('nativephp.png')
         ->url('https://github.com/milwad-dev')
@@ -22,6 +23,7 @@ it('menubar with create', function () {
 
     $this->assertTrue($menuBarArray['showDockIcon']);
     $this->assertTrue($menuBarArray['alwaysOnTop']);
+    $this->assertTrue($menuBarArray['showOnAllWorkspaces']);
     $this->assertEquals('milwad', $menuBarArray['label']);
     $this->assertEquals('https://github.com/milwad-dev', $menuBarArray['url']);
     $this->assertEquals('nativephp.png', $menuBarArray['icon']);


### PR DESCRIPTION
Introduce a new `showOnAllWorkspaces` property and its corresponding method to configure this behavior. Update the `toArray` method to include this property and adjust tests to validate its functionality.

PR:
nativePHP/electron: https://github.com/NativePHP/electron/pull/211