### PR TITLE
Add AutoUpdater feature with events and facade support

### DIFF
--- a/src/AutoUpdater.php
+++ b/src/AutoUpdater.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Native\Laravel;
+
+use Native\Laravel\Client\Client;
+
+class AutoUpdater
+{
+    public function __construct(protected Client $client) {}
+
+    public function checkForUpdates(): void
+    {
+        $this->client->post('auto-updater/check-for-updates');
+    }
+
+    public function quitAndInstall(): void
+    {
+        $this->client->post('auto-updater/quit-and-install');
+    }
+}

--- a/src/Events/AutoUpdater/CheckingForUpdate.php
+++ b/src/Events/AutoUpdater/CheckingForUpdate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Native\Laravel\Events\AutoUpdater;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CheckingForUpdate implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct() {}
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Events/AutoUpdater/Error.php
+++ b/src/Events/AutoUpdater/Error.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Native\Laravel\Events\AutoUpdater;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class Error implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public string $error) {}
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Events/AutoUpdater/UpdateAvailable.php
+++ b/src/Events/AutoUpdater/UpdateAvailable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Native\Laravel\Events\AutoUpdater;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateAvailable implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct() {}
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Events/AutoUpdater/UpdateDownloaded.php
+++ b/src/Events/AutoUpdater/UpdateDownloaded.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Native\Laravel\Events\AutoUpdater;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateDownloaded implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public string $version, public string $downloadedFile, public string $releaseDate, public ?string $releaseNotes, public ?string $releaseName) {}
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Events/AutoUpdater/UpdateNotAvailable.php
+++ b/src/Events/AutoUpdater/UpdateNotAvailable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Native\Laravel\Events\AutoUpdater;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateNotAvailable implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function broadcastOn()
+    {
+        return [
+            new Channel('nativephp'),
+        ];
+    }
+}

--- a/src/Facades/AutoUpdater.php
+++ b/src/Facades/AutoUpdater.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Native\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static void checkForUpdates()
+ * @method static void quitAndInstall()
+ */
+class AutoUpdater extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \Native\Laravel\AutoUpdater::class;
+    }
+}


### PR DESCRIPTION
Introduces the `AutoUpdater` class to manage update processes via the client. Adds events such as `UpdateAvailable`, `UpdateDownloaded`, and others for broadcasting update states. A facade is also provided for convenient usage.

PR:
NativePHP/electron: https://github.com/NativePHP/electron/pull/213