### PR TITLE
Add 'description' and 'website' fields to nativephp config

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -44,7 +44,7 @@ return [
     /**
      * The Website of your application.
      */
-    'website' => env('NATIVEPHP_APP_WEBSITE'),
+    'website' => env('NATIVEPHP_APP_WEBSITE', 'https://nativephp.com'),
 
     /**
      * The default service provider for your application. This provider

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -39,7 +39,7 @@ return [
     /**
      * The description of your application.
      */
-    'description' => env('NATIVEPHP_APP_DESCRIPTION'),
+    'description' => env('NATIVEPHP_APP_DESCRIPTION', 'An awesome app built with NativePHP'),
 
     /**
      * The Website of your application.

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -37,6 +37,16 @@ return [
     'copyright' => env('NATIVEPHP_APP_COPYRIGHT'),
 
     /**
+     * The description of your application.
+     */
+    'description' => env('NATIVEPHP_APP_DESCRIPTION'),
+
+    /**
+     * The Website of your application.
+     */
+    'website' => env('NATIVEPHP_APP_WEBSITE'),
+
+    /**
      * The default service provider for your application. This provider
      * takes care of bootstrapping your application and configuring
      * any global hotkeys, menus, windows, etc.


### PR DESCRIPTION
These new fields allow developers to define a description and website for their application via environment variables. This enhances configurability and provides more application metadata.

PR:
NativePHP/electron: https://github.com/NativePHP/electron/pull/214