### PR TITLE
Update fix-php-code-style-issues.yml

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.sha }}
 
       - name: Check PHP code style issues
         if: github.event_name == 'push'


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/fix-php-code-style-issues.yml` file. The change ensures that the workflow falls back to using the commit SHA (`github.sha`) if `github.head_ref` is not available, improving reliability in certain scenarios.

* [`.github/workflows/fix-php-code-style-issues.yml`](diffhunk://#diff-1fe0287e0253ce9640da25ffe9449e0b9ec6d39929535e1dd03eb85dfeecfd2aL25-R25): Updated the `ref` parameter in the `actions/checkout` step to use `github.head_ref || github.sha` for better fallback behavior.