### PR TITLE
Update QueueConfig sleep type hint to allow float values

### DIFF
--- a/src/DTOs/QueueConfig.php
+++ b/src/DTOs/QueueConfig.php
@@ -12,7 +12,7 @@ class QueueConfig
         public readonly array $queuesToConsume,
         public readonly int $memoryLimit,
         public readonly int $timeout,
-        public readonly int $sleep,
+        public readonly int|float $sleep,
     ) {}
 
     /**


### PR DESCRIPTION
This relates to the feedback on https://github.com/NativePHP/laravel/pull/564 and updates the type hint for the sleep parameter to match Laravel’s implementation:
https://github.com/laravel/framework/blob/81cd4d6e52eb21637ae87d0398296da7c90756dd/src/Illuminate/Queue/Worker.php#L810