### PR TITLE
Add support for detailed auto-updater event handling

### DIFF
--- a/src/AutoUpdater.php
+++ b/src/AutoUpdater.php
@@ -17,4 +17,9 @@ class AutoUpdater
     {
         $this->client->post('auto-updater/quit-and-install');
     }
+
+    public function downloadUpdate(): void
+    {
+        $this->client->post('auto-updater/download-update');
+    }
 }

--- a/src/Events/AutoUpdater/DownloadProgress.php
+++ b/src/Events/AutoUpdater/DownloadProgress.php
@@ -12,7 +12,13 @@ class DownloadProgress implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public function __construct(public int $total, public int $delta, public int $transferred, public float $percent, public int $bytesPerSecond) {}
+    public function __construct(
+        public int $total,
+        public int $delta,
+        public int $transferred,
+        public float $percent,
+        public int $bytesPerSecond
+    ) {}
 
     public function broadcastOn()
     {

--- a/src/Events/AutoUpdater/Error.php
+++ b/src/Events/AutoUpdater/Error.php
@@ -12,7 +12,11 @@ class Error implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public function __construct(public string $error) {}
+    public function __construct(
+        public string $name,
+        public string $message,
+        public ?string $stack,
+    ) {}
 
     public function broadcastOn()
     {

--- a/src/Events/AutoUpdater/UpdateCancelled.php
+++ b/src/Events/AutoUpdater/UpdateCancelled.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class UpdateAvailable implements ShouldBroadcastNow
+class UpdateCancelled implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/src/Events/AutoUpdater/UpdateDownloaded.php
+++ b/src/Events/AutoUpdater/UpdateDownloaded.php
@@ -12,7 +12,16 @@ class UpdateDownloaded implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public function __construct(public string $version, public string $downloadedFile, public string $releaseDate, public ?string $releaseNotes, public ?string $releaseName) {}
+    public function __construct(
+        public string $downloadedFile,
+        public string $version,
+        public array $files,
+        public string $releaseDate,
+        public ?string $releaseName,
+        public string|array|null $releaseNotes,
+        public ?int $stagingPercentage,
+        public ?string $minimumSystemVersion
+    ) {}
 
     public function broadcastOn()
     {

--- a/src/Events/AutoUpdater/UpdateNotAvailable.php
+++ b/src/Events/AutoUpdater/UpdateNotAvailable.php
@@ -12,6 +12,16 @@ class UpdateNotAvailable implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    public function __construct(
+        public string $version,
+        public array $files,
+        public string $releaseDate,
+        public ?string $releaseName,
+        public string|array|null $releaseNotes,
+        public ?int $stagingPercentage,
+        public ?string $minimumSystemVersion,
+    ) {}
+
     public function broadcastOn()
     {
         return [

--- a/src/Facades/AutoUpdater.php
+++ b/src/Facades/AutoUpdater.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static void checkForUpdates()
  * @method static void quitAndInstall()
+ * @method static void downloadUpdate()
  */
 class AutoUpdater extends Facade
 {


### PR DESCRIPTION
Expanded event constructors to include more detailed update metadata such as version, files, release information, and system requirements. Added a `downloadUpdate` method to the AutoUpdater facade. These updates enhance event broadcasting and improve client interaction with the auto-updater.

PR:
NativePHP/electron: https://github.com/NativePHP/electron/pull/220