### PR TITLE
feat: add WipeDatabaseCommand for database management

### DIFF
--- a/src/Commands/WipeDatabaseCommand.php
+++ b/src/Commands/WipeDatabaseCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Native\Laravel\Commands;
+
+use Illuminate\Database\Console\WipeCommand as BaseWipeCommand;
+use Native\Laravel\NativeServiceProvider;
+
+class WipeDatabaseCommand extends BaseWipeCommand
+{
+    protected $name = 'native:db:wipe';
+
+    protected $description = 'Wipe the database in the NativePHP development environment';
+
+    public function handle()
+    {
+        (new NativeServiceProvider($this->laravel))->rewriteDatabase();
+
+        return parent::handle();
+    }
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -15,6 +15,7 @@ use Native\Laravel\Commands\LoadPHPConfigurationCommand;
 use Native\Laravel\Commands\LoadStartupConfigurationCommand;
 use Native\Laravel\Commands\MigrateCommand;
 use Native\Laravel\Commands\SeedDatabaseCommand;
+use Native\Laravel\Commands\WipeDatabaseCommand;
 use Native\Laravel\Contracts\ChildProcess as ChildProcessContract;
 use Native\Laravel\Contracts\GlobalShortcut as GlobalShortcutContract;
 use Native\Laravel\Contracts\PowerMonitor as PowerMonitorContract;
@@ -42,6 +43,7 @@ class NativeServiceProvider extends PackageServiceProvider
                 FreshCommand::class,
                 MigrateCommand::class,
                 SeedDatabaseCommand::class,
+                WipeDatabaseCommand::class,
             ])
             ->hasConfigFile()
             ->hasRoute('api')


### PR DESCRIPTION
Introduced the WipeDatabaseCommand to streamline database wiping in the NativePHP development environment.