### PR TITLE
fix: add default values for optional parameters in events

### DIFF
--- a/src/Events/AutoUpdater/Error.php
+++ b/src/Events/AutoUpdater/Error.php
@@ -15,7 +15,7 @@ class Error implements ShouldBroadcastNow
     public function __construct(
         public string $name,
         public string $message,
-        public ?string $stack,
+        public ?string $stack = null,
     ) {}
 
     public function broadcastOn()

--- a/src/Events/AutoUpdater/UpdateAvailable.php
+++ b/src/Events/AutoUpdater/UpdateAvailable.php
@@ -16,10 +16,10 @@ class UpdateAvailable implements ShouldBroadcastNow
         public string $version,
         public array $files,
         public string $releaseDate,
-        public ?string $releaseName,
-        public string|array|null $releaseNotes,
-        public ?int $stagingPercentage,
-        public ?string $minimumSystemVersion,
+        public ?string $releaseName = null,
+        public string|array|null $releaseNotes = null,
+        public ?int $stagingPercentage = null,
+        public ?string $minimumSystemVersion = null,
     ) {}
 
     public function broadcastOn()

--- a/src/Events/AutoUpdater/UpdateCancelled.php
+++ b/src/Events/AutoUpdater/UpdateCancelled.php
@@ -16,10 +16,10 @@ class UpdateCancelled implements ShouldBroadcastNow
         public string $version,
         public array $files,
         public string $releaseDate,
-        public ?string $releaseName,
-        public string|array|null $releaseNotes,
-        public ?int $stagingPercentage,
-        public ?string $minimumSystemVersion,
+        public ?string $releaseName = null,
+        public string|array|null $releaseNotes = null,
+        public ?int $stagingPercentage = null,
+        public ?string $minimumSystemVersion = null,
     ) {}
 
     public function broadcastOn()

--- a/src/Events/AutoUpdater/UpdateDownloaded.php
+++ b/src/Events/AutoUpdater/UpdateDownloaded.php
@@ -17,10 +17,10 @@ class UpdateDownloaded implements ShouldBroadcastNow
         public string $version,
         public array $files,
         public string $releaseDate,
-        public ?string $releaseName,
-        public string|array|null $releaseNotes,
-        public ?int $stagingPercentage,
-        public ?string $minimumSystemVersion
+        public ?string $releaseName = null,
+        public string|array|null $releaseNotes = null,
+        public ?int $stagingPercentage = null,
+        public ?string $minimumSystemVersion = null,
     ) {}
 
     public function broadcastOn()

--- a/src/Events/AutoUpdater/UpdateNotAvailable.php
+++ b/src/Events/AutoUpdater/UpdateNotAvailable.php
@@ -16,10 +16,10 @@ class UpdateNotAvailable implements ShouldBroadcastNow
         public string $version,
         public array $files,
         public string $releaseDate,
-        public ?string $releaseName,
-        public string|array|null $releaseNotes,
-        public ?int $stagingPercentage,
-        public ?string $minimumSystemVersion,
+        public ?string $releaseName = null,
+        public string|array|null $releaseNotes = null,
+        public ?int $stagingPercentage = null,
+        public ?string $minimumSystemVersion = null,
     ) {}
 
     public function broadcastOn()


### PR DESCRIPTION
add default values for optional parameters in update auto-updater event classes.

Fixes https://github.com/NativePHP/laravel/issues/614