### PR TITLE
fix: native:seed command

### DIFF
--- a/src/Commands/SeedDatabaseCommand.php
+++ b/src/Commands/SeedDatabaseCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 )]
 class SeedDatabaseCommand extends BaseSeedCommand
 {
-    protected $name = 'native:seed';
+    protected $signature = 'native:seed';
     
     public function handle()
     {

--- a/src/Commands/SeedDatabaseCommand.php
+++ b/src/Commands/SeedDatabaseCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 class SeedDatabaseCommand extends BaseSeedCommand
 {
     protected $signature = 'native:seed';
-    
+
     public function handle()
     {
         (new NativeServiceProvider($this->laravel))->rewriteDatabase();

--- a/src/Commands/SeedDatabaseCommand.php
+++ b/src/Commands/SeedDatabaseCommand.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Attribute\AsCommand;
 )]
 class SeedDatabaseCommand extends BaseSeedCommand
 {
+    protected $name = 'native:seed';
+    
     public function handle()
     {
         (new NativeServiceProvider($this->laravel))->rewriteDatabase();


### PR DESCRIPTION
The "native:seed" command cannot be found because it is registered under multiple names.

Fixes #627