### PR TITLE
feat: add Azure Trusted Signing support

### DIFF
--- a/config/nativephp-internal.php
+++ b/config/nativephp-internal.php
@@ -49,6 +49,19 @@ return [
     ],
 
     /**
+     * The credentials to use Azure Trusted Signing service.
+     */
+    'azure_trusted_signing' => [
+        'tenant_id' => env('AZURE_TENANT_ID'),
+        'client_id' => env('AZURE_CLIENT_ID'),
+        'client_secret' => env('AZURE_CLIENT_SECRET'),
+        'publisher_name' => env('NATIVEPHP_AZURE_PUBLISHER_NAME'),
+        'endpoint' => env('NATIVEPHP_AZURE_ENDPOINT'),
+        'certificate_profile_name' => env('NATIVEPHP_AZURE_CERTIFICATE_PROFILE_NAME'),
+        'code_signing_account_name' => env('NATIVEPHP_AZURE_CODE_SIGNING_ACCOUNT_NAME'),
+    ],
+
+    /**
      * The binary path of PHP for NativePHP to use at build.
      */
     'php_binary_path' => env('NATIVEPHP_PHP_BINARY_PATH'),

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -60,6 +60,7 @@ return [
      */
     'cleanup_env_keys' => [
         'AWS_*',
+        'AZURE_*',
         'GITHUB_*',
         'DO_SPACES_*',
         '*_SECRET',
@@ -68,6 +69,10 @@ return [
         'NATIVEPHP_APPLE_ID',
         'NATIVEPHP_APPLE_ID_PASS',
         'NATIVEPHP_APPLE_TEAM_ID',
+        'NATIVEPHP_AZURE_PUBLISHER_NAME',
+        'NATIVEPHP_AZURE_ENDPOINT',
+        'NATIVEPHP_AZURE_CERTIFICATE_PROFILE_NAME',
+        'NATIVEPHP_AZURE_CODE_SIGNING_ACCOUNT_NAME',
     ],
 
     /**

--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -4,19 +4,19 @@ namespace Native\Laravel\Commands;
 
 use Composer\InstalledVersions;
 use Illuminate\Console\Command;
-use function Laravel\Prompts\info;
-use function Laravel\Prompts\note;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Support\Collection;
-use function Laravel\Prompts\error;
-use function Laravel\Prompts\intro;
-use function Laravel\Prompts\outro;
-
-use function Laravel\Prompts\select;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Native\Laravel\Support\Environment;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Illuminate\Contracts\Console\PromptsForMissingInput;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\outro;
+use function Laravel\Prompts\select;
 
 #[AsCommand(
     name: 'native:debug',

--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -4,19 +4,19 @@ namespace Native\Laravel\Commands;
 
 use Composer\InstalledVersions;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Console\PromptsForMissingInput;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
 use Illuminate\Support\Collection;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\outro;
+
+use function Laravel\Prompts\select;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Native\Laravel\Support\Environment;
 use Symfony\Component\Console\Attribute\AsCommand;
-
-use function Laravel\Prompts\error;
-use function Laravel\Prompts\info;
-use function Laravel\Prompts\intro;
-use function Laravel\Prompts\note;
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\select;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 
 #[AsCommand(
     name: 'native:debug',
@@ -111,6 +111,14 @@ class DebugCommand extends Command implements PromptsForMissingInput
             && config('nativephp-internal.notarization.apple_id_pass')
             && config('nativephp-internal.notarization.apple_team_id');
 
+        $isAzureTrustedSigningConfigured = config('nativephp-internal.azure_trusted_signing.tenant_id')
+            && config('nativephp-internal.azure_trusted_signing.client_id')
+            && config('nativephp-internal.azure_trusted_signing.client_secret')
+            && config('nativephp-internal.azure_trusted_signing.publisher_name')
+            && config('nativephp-internal.azure_trusted_signing.endpoint')
+            && config('nativephp-internal.azure_trusted_signing.certificate_profile_name')
+            && config('nativephp-internal.azure_trusted_signing.code_signing_account_name');
+
         $this->debugInfo->put(
             'NativePHP',
             [
@@ -122,6 +130,7 @@ class DebugCommand extends Command implements PromptsForMissingInput
                         'Post' => config('nativephp.postbuild'),
                     ],
                     'NotarizationEnabled' => $isNotarizationConfigured,
+                    'AzureTrustedSigningEnabled' => $isAzureTrustedSigningConfigured,
                     'CustomPHPBinary' => config('nativephp-internal.php_binary_path') ?? false,
                 ],
             ]


### PR DESCRIPTION
Add configuration for Azure Trusted Signing service for Windows code signing. This includes credential settings and environment variable cleanup for Azure-related keys.

🤖 Generated with [Claude Code](https://claude.ai/code)