### PR TITLE
add `skipTaskbar` and `hiddenInMissionControl` window options

### DIFF
--- a/src/Windows/Window.php
+++ b/src/Windows/Window.php
@@ -44,6 +44,10 @@ class Window
 
     protected bool $focusable = true;
 
+    protected bool $skipTaskbar = false;
+
+    protected bool $hiddenInMissionControl = false;
+
     protected bool $focused = false;
 
     protected bool $hasShadow = true;
@@ -153,6 +157,20 @@ class Window
     public function focusable($value = true): self
     {
         $this->focusable = $value;
+
+        return $this;
+    }
+
+    public function skipTaskbar($value = true): self
+    {
+        $this->skipTaskbar = $value;
+
+        return $this;
+    }
+
+    public function hiddenInMissionControl($value = true): self
+    {
+        $this->hiddenInMissionControl = $value;
 
         return $this;
     }
@@ -323,6 +341,8 @@ class Window
             'maxWidth' => $this->maxWidth,
             'maxHeight' => $this->maxHeight,
             'focusable' => $this->focusable,
+            'skipTaskbar' => $this->skipTaskbar,
+            'hiddenInMissionControl' => $this->hiddenInMissionControl,
             'hasShadow' => $this->hasShadow,
             'frame' => $this->frame,
             'titleBarStyle' => $this->titleBarStyle,

--- a/tests/Windows/WindowTest.php
+++ b/tests/Windows/WindowTest.php
@@ -16,6 +16,8 @@ it('test window', function () {
         ->titleBarStyle('milwad')
         ->rememberState()
         ->frameless()
+        ->skipTaskbar()
+        ->hiddenInMissionControl()
         ->focusable()
         ->hasShadow()
         ->alwaysOnTop()
@@ -36,6 +38,8 @@ it('test window', function () {
     expect($windowArray['titleBarStyle'])->toBe('milwad');
     expect($windowArray['rememberState'])->toBeTrue();
     expect($windowArray['frame'])->toBeFalse();
+    expect($windowArray['skipTaskbar'])->toBeTrue();
+    expect($windowArray['hiddenInMissionControl'])->toBeTrue();
     expect($windowArray['focusable'])->toBeTrue();
     expect($windowArray['hasShadow'])->toBeTrue();
     expect($windowArray['alwaysOnTop'])->toBeTrue();


### PR DESCRIPTION
Introduced `skipTaskbar` and `hiddenInMissionControl` methods to configure window behavior. Updated `toArray` to include these new properties and extended tests to validate functionality.

PR
NativePHP/electron: https://github.com/NativePHP/electron/pull/240