### PR TITLE
Add "Powered by JetBrains" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Please review [our security policy](../../security/policy) on how to report secu
 - [Simon Hamp](https://github.com/simonhamp)
 - [All Contributors](../../contributors)
 
+### Powered by
+<a href="https://jb.gg/OpenSource" target="_blank">
+<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg" alt="JetBrains logo" width="150">
+</a>
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.


### PR DESCRIPTION
Hi @simonhamp,

I reached out to JetBrains to ask if they would be willing to support our project through their Open Source Support Program — and they said yes.

To be eligible, the only requirement is to add a short note in the README, mentioning that the project is “powered by JetBrains.” This is a common practice in many open-source projects they support.

I want to emphasize that I'm not doing this for personal benefit, but to provide real value to everyone actively contributing to the project. With this, all contributors would be eligible to receive free licenses for JetBrains products like IntelliJ, PhpStorm, WebStorm, and others — which can be a great help and motivation, especially for new contributors.

So I’d like to propose adding a brief mention in the README to acknowledge their support. I believe it’s a small change with a clear benefit to the project and the community.

https://www.jetbrains.com/community/opensource/#support

What do you think?

Chears 🙂 