### PR TITLE
Fix `native:seed` command

### DIFF
--- a/src/Commands/SeedDatabaseCommand.php
+++ b/src/Commands/SeedDatabaseCommand.php
@@ -5,6 +5,8 @@ namespace Native\Laravel\Commands;
 use Illuminate\Database\Console\Seeds\SeedCommand as BaseSeedCommand;
 use Native\Laravel\NativeServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(
     name: 'native:seed',
@@ -14,10 +16,18 @@ class SeedDatabaseCommand extends BaseSeedCommand
 {
     protected $signature = 'native:seed';
 
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addArgument('class', mode: InputArgument::OPTIONAL, description: 'The class name of the root seeder');
+        $this->addOption('class', mode: InputOption::VALUE_OPTIONAL, description: 'The class name of the root seeder', default: 'Database\\Seeders\\DatabaseSeeder');
+    }
+
     public function handle()
     {
-        $this->addOption('database', default: null);
-        $this->addArgument('class', default: 'DatabaseSeeder');
+        // Add the database option here so it won't show up in `--help`
+        $this->addOption('database', mode: InputOption::VALUE_REQUIRED, default: 'nativephp');
 
         (new NativeServiceProvider($this->laravel))->rewriteDatabase();
 

--- a/src/Commands/SeedDatabaseCommand.php
+++ b/src/Commands/SeedDatabaseCommand.php
@@ -16,6 +16,9 @@ class SeedDatabaseCommand extends BaseSeedCommand
 
     public function handle()
     {
+        $this->addOption('database', default: null);
+        $this->addArgument('class', default: 'DatabaseSeeder');
+
         (new NativeServiceProvider($this->laravel))->rewriteDatabase();
 
         return parent::handle();


### PR DESCRIPTION
The base SeedCommand class expects some input to be set. This caused the `native:seed` command to error.

I've added the `database` input option under the hood. The base command was expecting this input to be present but we don't want this to be altered by the dev. So I've put that in the handle method ( also so it won't show up when using `--help`).

The `class` argument I've put in the configure method. I've added it both as an argument & an option so the command signature is similar to laravel's `db:seed` command.

Fixes #677 
