### PR TITLE
Allow optional suppression of opening sub-windows

### DIFF
--- a/src/Facades/Window.php
+++ b/src/Facades/Window.php
@@ -18,6 +18,7 @@ use Native\Laravel\Fakes\WindowManagerFake;
  * @method static void maximize($id = null)
  * @method static void minimize($id = null)
  * @method static void zoomFactor(float $zoomFactor = 1.0)
+ * @method static void suppressNewWindows()
  */
 class Window extends Facade
 {

--- a/src/Windows/Window.php
+++ b/src/Windows/Window.php
@@ -70,6 +70,8 @@ class Window
 
     protected float $zoomFactor = 1.0;
 
+    protected bool $suppressNewWindows = false;
+
     public function __construct(string $id)
     {
         $this->id = $id;
@@ -342,6 +344,13 @@ class Window
         return $this;
     }
 
+    public function suppressNewWindows(): self
+    {
+        $this->suppressNewWindows = true;
+
+        return $this;
+    }
+
     public function toArray()
     {
         return [
@@ -381,6 +390,7 @@ class Window
             'transparent' => $this->transparent,
             'webPreferences' => $this->webPreferences,
             'zoomFactor' => $this->zoomFactor,
+            'suppressNewWindows' => $this->suppressNewWindows,
         ];
     }
 


### PR DESCRIPTION
**This PR allows developers to disable the opening of potentially unwanted pop-up windows.**

By default, Electron doesn't prevent sub-windows to be opened out of a window. This would for instance be the case if a user middle-clicks a link. This behaviour is potentially undesirable in a desktop application, as it enables the user to "break out" of a window.

To prevent additional windows from opening, this PR adds a `suppressNewWindows()` method that can be applied when opening a new window. It will prevent any pop-up windows being opened.

_Electron PR:_ https://github.com/NativePHP/electron/pull/249
_Docs PR:_ https://github.com/NativePHP/nativephp.com/pull/200

If there's anything you'd like me to tweak or improve in this PR, please let me know. 😊