### PR TITLE
Add possibility to prevent navigation away from current domain or page

### DIFF
--- a/src/Facades/Window.php
+++ b/src/Facades/Window.php
@@ -18,6 +18,8 @@ use Native\Laravel\Fakes\WindowManagerFake;
  * @method static void maximize($id = null)
  * @method static void minimize($id = null)
  * @method static void zoomFactor(float $zoomFactor = 1.0)
+ * @method static void preventLeaveDomain(bool $preventLeaveDomain = true)
+ * @method static void preventLeavePage(bool $preventLeavePage = true): self
  */
 class Window extends Facade
 {

--- a/src/Windows/Window.php
+++ b/src/Windows/Window.php
@@ -70,6 +70,10 @@ class Window
 
     protected float $zoomFactor = 1.0;
 
+    protected bool $preventLeaveDomain = false;
+
+    protected bool $preventLeavePage = false;
+
     public function __construct(string $id)
     {
         $this->id = $id;
@@ -342,6 +346,20 @@ class Window
         return $this;
     }
 
+    public function preventLeaveDomain(bool $preventLeaveDomain = true): self
+    {
+        $this->preventLeaveDomain = $preventLeaveDomain;
+
+        return $this;
+    }
+
+    public function preventLeavePage(bool $preventLeavePage = true): self
+    {
+        $this->preventLeavePage = $preventLeavePage;
+
+        return $this;
+    }
+
     public function toArray()
     {
         return [
@@ -381,6 +399,8 @@ class Window
             'transparent' => $this->transparent,
             'webPreferences' => $this->webPreferences,
             'zoomFactor' => $this->zoomFactor,
+            'preventLeaveDomain' => $this->preventLeaveDomain,
+            'preventLeavePage' => $this->preventLeavePage,
         ];
     }
 


### PR DESCRIPTION
**This PR allows to restrict navigation within a window so that the user cannot navigate away from the current domain or page.**

When implementing kiosk-type applications, you may want to give users access to certain pages or domains that are not directly under your control. In such cases, users may be able to navigate away from the page they are viewing, which is often undesirable.

This PR introduces two new methods on the `Window` facade which allow you to restrict in-window navigation. `preventLeaveDomain` would allow the user to navigate within the original host name. `preventLeavePage` would restrict any navigation (except anchors or URL parameters).

_Electron PR:_ [tbd]