### PR TITLE
Enhancement/add configurable webpreferences to menubar

### DIFF
--- a/src/Facades/MenuBar.php
+++ b/src/Facades/MenuBar.php
@@ -14,6 +14,7 @@ use Native\Laravel\Menu\Menu;
  * @method static void icon(string $icon)
  * @method static void resize(int $width, int $height)
  * @method static void contextMenu(Menu $contextMenu)
+ * @method static void webPreferences(array $preferences)
  */
 class MenuBar extends Facade
 {

--- a/src/Facades/Window.php
+++ b/src/Facades/Window.php
@@ -21,6 +21,7 @@ use Native\Laravel\Fakes\WindowManagerFake;
  * @method static void preventLeaveDomain(bool $preventLeaveDomain = true)
  * @method static void preventLeavePage(bool $preventLeavePage = true): self
  * @method static void suppressNewWindows()
+ * @method static void webPreferences(array $preferences)
  */
 class Window extends Facade
 {

--- a/src/MenuBar/MenuBar.php
+++ b/src/MenuBar/MenuBar.php
@@ -34,6 +34,8 @@ class MenuBar
 
     protected bool $showOnAllWorkspaces = false;
 
+    protected array $webPreferences = [];
+
     protected Client $client;
 
     public function __construct()
@@ -111,6 +113,13 @@ class MenuBar
         return $this;
     }
 
+    public function webPreferences(array $preferences): static
+    {
+        $this->webPreferences = $preferences;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return [
@@ -132,6 +141,7 @@ class MenuBar
             'contextMenu' => ! is_null($this->contextMenu) ? $this->contextMenu->toArray()['submenu'] : null,
             'alwaysOnTop' => $this->alwaysOnTop,
             'showOnAllWorkspaces' => $this->showOnAllWorkspaces,
+            'webPreferences' => $this->webPreferences,
         ];
     }
 }


### PR DESCRIPTION
While working on the updated security preferences (https://github.com/NativePHP/electron/pull/255) I noticed that the MenuBar does not allow us to pass custom webPreferences.

This PR adds a `webPreferences` method to the MenuBar, making this feature symmetrical with regular Windows.

I've added the Electron side of this to this [PR](https://github.com/NativePHP/electron/pull/255) since it touches the same code

