### PR TITLE
Add method to change notification sound

### DIFF
--- a/src/Facades/Notification.php
+++ b/src/Facades/Notification.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static static title(string $title)
  * @method static static event(string $event)
  * @method static static sound(string $sound)
+ * @method static static silent(bool $silent = true)
  * @method static static message(string $body)
  * @method static static reference(string $reference)
  * @method static static hasReply(string $placeholder = '')

--- a/src/Facades/Notification.php
+++ b/src/Facades/Notification.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static static title(string $title)
  * @method static static event(string $event)
+ * @method static static sound(string $sound)
  * @method static static message(string $body)
  * @method static static reference(string $reference)
  * @method static static hasReply(string $placeholder = '')

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -15,6 +15,8 @@ class Notification
     protected string $event = '';
 
     protected string $sound = '';
+    
+    protected bool $silent = false;
 
     private bool $hasReply = false;
 
@@ -60,6 +62,13 @@ class Notification
         return $this;
     }
 
+    public function silent(bool $silent = true): self
+    {
+        $this->silent = $silent;
+
+        return $this;
+    }
+
     public function hasReply(string $placeholder = ''): self
     {
         $this->hasReply = true;
@@ -90,6 +99,7 @@ class Notification
             'body' => $this->body,
             'event' => $this->event,
             'sound' => $this->sound,
+            'silent' => $this->silent,
             'hasReply' => $this->hasReply,
             'replyPlaceholder' => $this->replyPlaceholder,
             'actions' => array_map(fn (string $label) => [

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -14,6 +14,8 @@ class Notification
 
     protected string $event = '';
 
+    protected string $sound = '';
+
     private bool $hasReply = false;
 
     private string $replyPlaceholder = '';
@@ -51,6 +53,13 @@ class Notification
         return $this;
     }
 
+    public function sound(string $sound): self
+    {
+        $this->sound = $sound;
+
+        return $this;
+    }
+
     public function hasReply(string $placeholder = ''): self
     {
         $this->hasReply = true;
@@ -80,6 +89,7 @@ class Notification
             'title' => $this->title,
             'body' => $this->body,
             'event' => $this->event,
+            'sound' => $this->sound,
             'hasReply' => $this->hasReply,
             'replyPlaceholder' => $this->replyPlaceholder,
             'actions' => array_map(fn (string $label) => [


### PR DESCRIPTION
This pull request adds support for sound notifications and silent mode to the `Notification` system. These changes allow notifications to specify a custom sound and to be marked as silent, providing more flexibility in how notifications are delivered and displayed.

**New notification features:**

* Added `sound` and `silent` properties to the `Notification` class, allowing notifications to specify a sound and whether they should be silent.
* Implemented `sound()` and `silent()` methods in the `Notification` class to set these new properties.
* Updated the `show()` method to include `sound` and `silent` in the notification payload.